### PR TITLE
Add scoring logic and modals

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,62 @@ from flask import Flask, render_template, request, redirect, url_for, jsonify
 import pandas as pd
 import os
 
+# scoring maps
+TECH_SCORES = {
+    'exp_dashboard_b2b': 4,
+    'exp_dynamic_reports': 6,
+    'exp_role_based_access': 3,
+    'exp_pos_mobile': 6,
+    'exp_data_sync': 3,
+    'exp_multistep_forms': 4,
+    'exp_low_digital_users': 5,
+    'exp_multilingual': 2,
+    'exp_portfolio_relevant': 2,
+}
+
+GENERAL_SCORES = {
+    'gender': {
+        'Male': -3,
+        'Female': 1,
+    },
+    'marital_status': {
+        'Single': 1,
+        'Married': 0,
+    },
+    'education': {
+        'Diploma': 0,
+        'Bachelor': 1,
+        'Master': 2,
+    },
+    'military_status': {
+        'Completed': 2,
+        'Exempt': 1,
+        'In Progress': -4,
+        'N/A': 0,
+    },
+    'job_status': {
+        'Employed': -1,
+        'Freelancer': 0,
+        'Unemployed': 1,
+    },
+    'can_start_from': {
+        '1 Week': 5,
+        'Less than a month': 2,
+        'More than a month': -5,
+    },
+}
+
+COLUMNS = [
+    'id', 'name', 'mobile', 'gender', 'marital_status', 'education', 'major',
+    'military_status', 'job_status', 'can_start_from', 'available_9_to_6',
+    'telegram_id', 'has_portfolio', 'ok_with_task', 'location',
+    'technical_experience_notes',
+    'exp_dashboard_b2b', 'exp_dynamic_reports', 'exp_role_based_access',
+    'exp_pos_mobile', 'exp_data_sync', 'exp_multistep_forms',
+    'exp_low_digital_users', 'exp_multilingual', 'exp_portfolio_relevant',
+    'interviewer_score', 'design_score', 'total_score'
+]
+
 app = Flask(__name__)
 
 # Path to Excel data file (placed alongside this script)
@@ -11,20 +67,17 @@ DATA_FILE = os.path.join(BASE_DIR, 'candidates.xlsx')
 # ensure the Excel file exists with the required columns
 def _ensure_file():
     if not os.path.exists(DATA_FILE):
-        df = pd.DataFrame(columns=[
-            'id',
-            'name', 'mobile', 'gender', 'marital_status', 'education', 'major', 'military_status',
-            'job_status', 'can_start_from', 'available_9_to_6', 'telegram_id',
-            'has_portfolio', 'ok_with_task', 'location', 'technical_experience_notes',
-            'exp_dashboard_b2b', 'exp_dynamic_reports', 'exp_role_based_access',
-            'exp_pos_mobile', 'exp_data_sync', 'exp_multistep_forms',
-            'exp_low_digital_users', 'exp_multilingual', 'exp_portfolio_relevant'
-        ])
+        df = pd.DataFrame(columns=COLUMNS)
         df.to_excel(DATA_FILE, index=False)
 
 def read_data():
     _ensure_file()
-    return pd.read_excel(DATA_FILE)
+    df = pd.read_excel(DATA_FILE)
+    # ensure all expected columns exist
+    for col in COLUMNS:
+        if col not in df.columns:
+            df[col] = ''
+    return df
 
 def write_data(df):
     df.to_excel(DATA_FILE, index=False)
@@ -33,10 +86,45 @@ def get_next_id():
     df = read_data()
     return int(df['id'].max() + 1) if not df.empty else 1
 
+def compute_total_score(row):
+    score = 0
+    # technical experience
+    for field, pts in TECH_SCORES.items():
+        if str(row.get(field, '')).strip() == 'Yes':
+            score += pts
+
+    # general items
+    for field, mapping in GENERAL_SCORES.items():
+        val = str(row.get(field, '')).strip()
+        score += mapping.get(val, 0)
+
+    # additional boolean fields
+    if str(row.get('available_9_to_6', '')) == 'Yes':
+        score += 5
+    if str(row.get('has_portfolio', '')) == 'Yes':
+        score += 5
+    if str(row.get('ok_with_task', '')) == 'Yes':
+        score += 2
+
+    # interviewer and design scores
+    try:
+        score += float(row.get('interviewer_score', 0))
+    except ValueError:
+        pass
+    try:
+        score += float(row.get('design_score', 0))
+    except ValueError:
+        pass
+
+    return score
+
 @app.route('/')
 def index():
     df = read_data()
-    # pass list of dicts to template
+    # compute total score for each candidate
+    for idx, row in df.iterrows():
+        df.at[idx, 'total_score'] = compute_total_score(row)
+    write_data(df)
     return render_template('index.html', candidates=df.to_dict(orient='records'))
 
 @app.route('/add', methods=['POST'])
@@ -56,7 +144,8 @@ def add_candidate():
         'location':'', 'technical_experience_notes':'',
         'exp_dashboard_b2b':'', 'exp_dynamic_reports':'', 'exp_role_based_access':'',
         'exp_pos_mobile':'', 'exp_data_sync':'', 'exp_multistep_forms':'',
-        'exp_low_digital_users':'', 'exp_multilingual':'', 'exp_portfolio_relevant':''
+        'exp_low_digital_users':'', 'exp_multilingual':'', 'exp_portfolio_relevant':'',
+        'interviewer_score':'', 'design_score':'', 'total_score':''
     }
     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
     write_data(df)
@@ -84,6 +173,8 @@ def edit_candidate(candidate_id):
     for key, value in request.form.items():
         if key in df.columns:
             df.loc[df['id'] == candidate_id, key] = value
+    row = df[df['id'] == candidate_id].iloc[0].to_dict()
+    df.loc[df['id'] == candidate_id, 'total_score'] = compute_total_score(row)
     write_data(df)
     return redirect(url_for('index'))
 

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -16,6 +16,9 @@
       <li class="nav-item">
         <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabExperience" type="button">Technical Experience</button>
       </li>
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabDesign" type="button">Design Score</button>
+      </li>
     </ul>
 
     <div class="tab-content">
@@ -79,7 +82,12 @@
           </div>
           <div class="col-md-3">
             <label class="form-label">Can Start From</label>
-            <input name="can_start_from" value="{{ candidate.can_start_from }}" type="date" class="form-control">
+            <select name="can_start_from" class="form-select">
+              <option value="">Select</option>
+              <option {% if candidate.can_start_from=='1 Week' %}selected{% endif %}>1 Week</option>
+              <option {% if candidate.can_start_from=='Less than a month' %}selected{% endif %}>Less than a month</option>
+              <option {% if candidate.can_start_from=='More than a month' %}selected{% endif %}>More than a month</option>
+            </select>
           </div>
           <div class="col-md-3">
             <div class="form-check mt-4">
@@ -106,6 +114,10 @@
           <div class="col-md-3">
             <label class="form-label">City / Area in Tehran</label>
             <input name="location" value="{{ candidate.location }}" type="text" class="form-control">
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Interviewer Score</label>
+            <input name="interviewer_score" value="{{ candidate.interviewer_score }}" type="number" class="form-control">
           </div>
         </div>
       </div>
@@ -153,6 +165,14 @@
           <div class="col-md-8">
             <label class="form-label">Other notes about technical fit</label>
             <textarea name="technical_experience_notes" class="form-control" rows="8">{{ candidate.technical_experience_notes }}</textarea>
+          </div>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="tabDesign">
+        <div class="row g-3">
+          <div class="col-md-3">
+            <label class="form-label">Design Score</label>
+            <input name="design_score" value="{{ candidate.design_score }}" type="number" class="form-control">
           </div>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
         <th>Name</th>
         <th>Mobile</th>
         <th>Gender</th>
+        <th>Total</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -39,6 +40,7 @@
         <td>{{ c.name }}</td>
         <td>{{ c.mobile }}</td>
         <td>{{ c.gender }}</td>
+        <td>{{ c.total_score }}</td>
         <td class="action-btns">
           <button class="btn btn-sm btn-info" data-id="{{ c.id }}">View</button>
           <a class="btn btn-sm btn-warning" href="/edit/{{ c.id }}">Edit</a>
@@ -74,8 +76,9 @@
             <option>Male</option>
             <option>Female</option>
           </select>
-        </div>
-      </div>
+</div>
+</div>
+
       <div class="modal-footer">
         <button class="btn btn-success">Add Candidate</button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
@@ -84,23 +87,47 @@
   </div>
 </div>
 
-<!-- View Drawer -->
-<div class="offcanvas offcanvas-end" tabindex="-1" id="viewDrawer">
-  <div class="offcanvas-header">
-    <h5 class="offcanvas-title">Candidate Details</h5>
-    <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirm Delete</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to delete this candidate?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" id="confirmDeleteBtn">Delete</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+      </div>
+    </div>
   </div>
-  <div class="offcanvas-body">
-    <ul class="nav nav-tabs mb-3">
-      <li class="nav-item">
-        <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabGeneral">General Info</button>
-      </li>
-      <li class="nav-item">
-        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabExperience">Experience</button>
-      </li>
-    </ul>
-    <div class="tab-content">
-      <div class="tab-pane fade show active" id="tabGeneral">
+</div>
+
+<!-- View Modal -->
+<div class="modal fade" id="viewModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Candidate Details</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="nav nav-tabs mb-3">
+          <li class="nav-item">
+            <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabGeneral">General Info</button>
+          </li>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabExperience">Experience</button>
+          </li>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabDesign">Design Score</button>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div class="tab-pane fade show active" id="tabGeneral">
         <p><strong>Name:</strong> <span id="view_name"></span></p>
         <p><strong>Mobile:</strong> <span id="view_mobile"></span></p>
         <p><strong>Gender:</strong> <span id="view_gender"></span></p>
@@ -113,6 +140,8 @@
         <p><strong>9–6 Available:</strong> <span id="view_available_9_to_6"></span></p>
         <p><strong>Telegram ID:</strong> <span id="view_telegram_id"></span></p>
         <p><strong>Location:</strong> <span id="view_location"></span></p>
+        <p><strong>Interviewer Score:</strong> <span id="view_interviewer_score"></span></p>
+        <p><strong>Total Score:</strong> <span id="view_total_score"></span></p>
       </div>
       <div class="tab-pane fade" id="tabExperience">
         <p><strong>B2B Dashboard Exp:</strong> <span id="view_exp_dashboard_b2b"></span></p>
@@ -125,6 +154,11 @@
         <p><strong>Multilingual:</strong> <span id="view_exp_multilingual"></span></p>
         <p><strong>Portfolio Relevant:</strong> <span id="view_exp_portfolio_relevant"></span></p>
         <p><strong>Technical Notes:</strong> <span id="view_technical_experience_notes"></span></p>
+          </div>
+          <div class="tab-pane fade" id="tabDesign">
+            <p><strong>Design Score:</strong> <span id="view_design_score"></span></p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -142,7 +176,7 @@
     });
   });
 
-  // View drawer loader - use delegation so new rows work too
+  // View modal loader - use delegation so new rows work too
   document.getElementById('candidateTable').addEventListener('click', e => {
     const btn = e.target.closest('.btn-info');
     if (btn) {
@@ -154,20 +188,25 @@
             const el = document.getElementById('view_' + k);
             if (el) el.innerText = v || '-';
           });
-          new bootstrap.Offcanvas(
-            document.getElementById('viewDrawer')
+          new bootstrap.Modal(
+            document.getElementById('viewModal')
           ).show();
         });
     }
   });
 
   // Delete confirmation
+  let deleteId = null;
   function confirmDelete(btn) {
-    if (!confirm('Are you sure you want to delete this candidate?')) return;
-    const id = btn.dataset.id;
-    fetch(`/delete/${id}`, { method: 'POST' })
-      .then(() => window.location.reload());
+    deleteId = btn.dataset.id;
+    new bootstrap.Modal(document.getElementById('deleteModal')).show();
   }
+
+  document.getElementById('confirmDeleteBtn').addEventListener('click', () => {
+    if (!deleteId) return;
+    fetch(`/delete/${deleteId}`, { method: 'POST' })
+      .then(() => window.location.reload());
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compute total candidate score using technical and general criteria
- track interviewer and design score
- switch view and delete actions to Bootstrap modals
- show score in listing and view
- update edit form with scoring fields

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687fd2e3571483269da6d22b20ccada9