### PR TITLE
Add look score and default design score

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ COLUMNS = [
     'exp_dashboard_b2b', 'exp_dynamic_reports', 'exp_role_based_access',
     'exp_pos_mobile', 'exp_data_sync', 'exp_multistep_forms',
     'exp_low_digital_users', 'exp_multilingual', 'exp_portfolio_relevant',
-    'interviewer_score', 'design_score', 'total_score'
+    'interviewer_score', 'design_score', 'look_score', 'total_score'
 ]
 
 app = Flask(__name__)
@@ -108,13 +108,17 @@ def compute_total_score(row):
     if str(row.get('ok_with_task', '')) == 'Yes':
         score += 2
 
-    # interviewer and design scores
+    # interviewer, design, and look scores
     try:
         score += float(row.get('interviewer_score', 0))
     except ValueError:
         pass
     try:
         score += float(row.get('design_score', 0))
+    except ValueError:
+        pass
+    try:
+        score += float(row.get('look_score', 0))
     except ValueError:
         pass
 
@@ -148,7 +152,7 @@ def add_candidate():
         'exp_dashboard_b2b':'', 'exp_dynamic_reports':'', 'exp_role_based_access':'',
         'exp_pos_mobile':'', 'exp_data_sync':'', 'exp_multistep_forms':'',
         'exp_low_digital_users':'', 'exp_multilingual':'', 'exp_portfolio_relevant':'',
-        'interviewer_score':'', 'design_score':'', 'total_score':''
+        'interviewer_score':'', 'design_score':'0', 'look_score':'0', 'total_score':''
     }
     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
     write_data(df)

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -119,6 +119,10 @@
             <label class="form-label">Interviewer Score</label>
             <input name="interviewer_score" value="{{ candidate.interviewer_score }}" type="number" class="form-control">
           </div>
+          <div class="col-md-3">
+            <label class="form-label">Look Score</label>
+            <input name="look_score" value="{{ candidate.look_score or 0 }}" type="number" class="form-control">
+          </div>
         </div>
       </div>
 
@@ -172,7 +176,7 @@
         <div class="row g-3">
           <div class="col-md-3">
             <label class="form-label">Design Score</label>
-            <input name="design_score" value="{{ candidate.design_score }}" type="number" class="form-control">
+            <input name="design_score" value="{{ candidate.design_score or 0 }}" type="number" class="form-control">
           </div>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -162,6 +162,7 @@
         <p><strong>Telegram ID:</strong> <span id="view_telegram_id"></span></p>
         <p><strong>Location:</strong> <span id="view_location"></span></p>
         <p><strong>Interviewer Score:</strong> <span id="view_interviewer_score"></span></p>
+        <p><strong>Look Score:</strong> <span id="view_look_score"></span></p>
         <p><strong>Total Score:</strong> <span id="view_total_score"></span></p>
       </div>
       <div class="tab-pane fade" id="tabExperience">


### PR DESCRIPTION
## Summary
- add numeric look_score to candidate records and scoring logic
- display look score in edit and view templates
- default design score to 0 in edit form

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688099b5f200832696b34d86a1d3de48