### PR TITLE
Set default score values to zero

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,7 +152,7 @@ def add_candidate():
         'exp_dashboard_b2b':'', 'exp_dynamic_reports':'', 'exp_role_based_access':'',
         'exp_pos_mobile':'', 'exp_data_sync':'', 'exp_multistep_forms':'',
         'exp_low_digital_users':'', 'exp_multilingual':'', 'exp_portfolio_relevant':'',
-        'interviewer_score':'', 'design_score':'0', 'look_score':'0', 'total_score':''
+        'interviewer_score':'0', 'design_score':'0', 'look_score':'0', 'total_score':''
     }
     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
     write_data(df)

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -117,7 +117,7 @@
           </div>
           <div class="col-md-3">
             <label class="form-label">Interviewer Score</label>
-            <input name="interviewer_score" value="{{ candidate.interviewer_score }}" type="number" class="form-control">
+            <input name="interviewer_score" value="{{ candidate.interviewer_score or 0 }}" type="number" class="form-control">
           </div>
           <div class="col-md-3">
             <label class="form-label">Look Score</label>


### PR DESCRIPTION
## Summary
- default `interviewer_score` to 0 on new candidate creation
- ensure edit form shows `interviewer_score` as 0 when empty

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68809f3879b0832687d27ccbc4975627