### PR TITLE
Add resume upload support

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -8,7 +8,7 @@
 <body class="p-4">
 <div class="container">
   <h3 class="mb-3">Edit Candidate</h3>
-  <form method="post">
+  <form method="post" enctype="multipart/form-data">
     <ul class="nav nav-tabs mb-3" id="editTabs" role="tablist">
       <li class="nav-item">
         <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabGeneral" type="button">General Info</button>
@@ -122,6 +122,13 @@
           <div class="col-md-3">
             <label class="form-label">Look Score</label>
             <input name="look_score" value="{{ candidate.look_score or 0 }}" type="number" class="form-control">
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Resume File</label>
+            <input type="file" name="resume" class="form-control">
+            {% if candidate.resume_file %}
+            <a href="/resumes/{{ candidate.resume_file }}" target="_blank" class="btn btn-link p-0">Current Resume</a>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,6 +53,7 @@
         <th>Gender</th>
         <th>Total</th>
         <th>Actions</th>
+        <th>Resume</th>
       </tr>
     </thead>
     <tbody>
@@ -67,6 +68,11 @@
           <a class="btn btn-sm btn-warning" href="/edit/{{ c.id }}">Edit</a>
           <button class="btn btn-sm btn-danger" data-id="{{ c.id }}" onclick="confirmDelete(this)">Delete</button>
         </td>
+        <td>
+          {% if c.resume_file %}
+          <a class="btn btn-sm btn-secondary" href="/resumes/{{ c.resume_file }}" target="_blank">Resume</a>
+          {% else %}-{% endif %}
+        </td>
       </tr>
     {% endfor %}
     </tbody>
@@ -76,7 +82,7 @@
 <!-- Add Candidate Modal -->
 <div class="modal fade" id="addCandidateModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
-    <form action="/add" method="post" class="modal-content">
+    <form action="/add" method="post" enctype="multipart/form-data" class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Add New Candidate</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -97,8 +103,12 @@
             <option>Male</option>
             <option>Female</option>
           </select>
-</div>
-</div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Resume File</label>
+          <input type="file" name="resume" class="form-control">
+        </div>
+      </div>
 
       <div class="modal-footer">
         <button class="btn btn-success">Add Candidate</button>


### PR DESCRIPTION
## Summary
- allow uploading resumes for each candidate
- store resumes in a `resumes` folder and keep filename based on candidate name
- show a Resume button in the candidate list
- enable uploading/updating resume in add and edit forms
- delete resume file when removing a candidate

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880a13426308326828e404bef79582f