### PR TITLE
Add candidate status and meeting scheduling

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,13 @@ COLUMNS = [
     'exp_dashboard_b2b', 'exp_dynamic_reports', 'exp_role_based_access',
     'exp_pos_mobile', 'exp_data_sync', 'exp_multistep_forms',
     'exp_low_digital_users', 'exp_multilingual', 'exp_portfolio_relevant',
-    'interviewer_score', 'design_score', 'look_score', 'resume_file', 'total_score'
+    'interviewer_score', 'design_score', 'look_score', 'resume_file', 'total_score',
+    'status',
+    'meeting1_date', 'meeting1_day', 'meeting1_time',
+    'meeting2_date', 'meeting2_day', 'meeting2_time',
+    'meeting3_date', 'meeting3_day', 'meeting3_time',
+    'meeting4_date', 'meeting4_day', 'meeting4_time',
+    'meeting5_date', 'meeting5_day', 'meeting5_time'
 ]
 
 app = Flask(__name__)
@@ -176,7 +182,13 @@ def add_candidate():
         'exp_pos_mobile':'', 'exp_data_sync':'', 'exp_multistep_forms':'',
         'exp_low_digital_users':'', 'exp_multilingual':'', 'exp_portfolio_relevant':'',
         'interviewer_score':'0', 'design_score':'0', 'look_score':'0',
-        'resume_file': stored_resume, 'total_score':''
+        'resume_file': stored_resume, 'total_score':'',
+        'status':'pending',
+        'meeting1_date':'', 'meeting1_day':'', 'meeting1_time':'',
+        'meeting2_date':'', 'meeting2_day':'', 'meeting2_time':'',
+        'meeting3_date':'', 'meeting3_day':'', 'meeting3_time':'',
+        'meeting4_date':'', 'meeting4_day':'', 'meeting4_time':'',
+        'meeting5_date':'', 'meeting5_day':'', 'meeting5_time':''
     }
     df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
     write_data(df)

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -19,6 +19,9 @@
       <li class="nav-item">
         <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabDesign" type="button">Design Score</button>
       </li>
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabMeetings" type="button">Meetings</button>
+      </li>
     </ul>
 
     <div class="tab-content">
@@ -78,6 +81,16 @@
               <option {% if candidate.job_status=='Employed' %}selected{% endif %}>Employed</option>
               <option {% if candidate.job_status=='Freelancer' %}selected{% endif %}>Freelancer</option>
               <option {% if candidate.job_status=='Unemployed' %}selected{% endif %}>Unemployed</option>
+            </select>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select">
+              <option value="pending" {% if candidate.status=='pending' or candidate.status=='' %}selected{% endif %}>pending</option>
+              <option value="called" {% if candidate.status=='called' %}selected{% endif %}>called</option>
+              <option value="Online meeting" {% if candidate.status=='Online meeting' %}selected{% endif %}>Online meeting</option>
+              <option value="offline meeting" {% if candidate.status=='offline meeting' %}selected{% endif %}>offline meeting</option>
+              <option value="rejected" {% if candidate.status=='rejected' %}selected{% endif %}>rejected</option>
             </select>
           </div>
           <div class="col-md-3">
@@ -185,6 +198,26 @@
             <label class="form-label">Design Score</label>
             <input name="design_score" value="{{ candidate.design_score or 0 }}" type="number" class="form-control">
           </div>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="tabMeetings">
+        <div class="row g-3">
+          {% for i in range(1,6) %}
+          <div class="col-12 d-flex align-items-end mb-2">
+            <div class="me-2">
+              <label class="form-label">Date {{ i }}</label>
+              <input type="text" name="meeting{{ i }}_date" value="{{ candidate['meeting' ~ i ~ '_date'] }}" class="form-control">
+            </div>
+            <div class="me-2">
+              <label class="form-label">Day</label>
+              <input type="text" name="meeting{{ i }}_day" value="{{ candidate['meeting' ~ i ~ '_day'] }}" class="form-control">
+            </div>
+            <div>
+              <label class="form-label">Time</label>
+              <input type="time" name="meeting{{ i }}_time" value="{{ candidate['meeting' ~ i ~ '_time'] }}" class="form-control">
+            </div>
+          </div>
+          {% endfor %}
         </div>
       </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,6 +54,7 @@
         <th>Total</th>
         <th>Actions</th>
         <th>Resume</th>
+        <th>Status</th>
       </tr>
     </thead>
     <tbody>
@@ -73,6 +74,7 @@
           <a class="btn btn-sm btn-secondary" href="/resumes/{{ c.resume_file }}" target="_blank">Resume</a>
           {% else %}-{% endif %}
         </td>
+        <td>{{ c.status }}</td>
       </tr>
     {% endfor %}
     </tbody>
@@ -156,6 +158,9 @@
           <li class="nav-item">
             <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabDesign">Design Score</button>
           </li>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabMeetings">Meetings</button>
+          </li>
         </ul>
         <div class="tab-content">
           <div class="tab-pane fade show active" id="tabGeneral">
@@ -167,6 +172,7 @@
         <p><strong>Major:</strong> <span id="view_major"></span></p>
         <p><strong>Military Status:</strong> <span id="view_military_status"></span></p>
         <p><strong>Job Status:</strong> <span id="view_job_status"></span></p>
+        <p><strong>Status:</strong> <span id="view_status"></span></p>
         <p><strong>Start From:</strong> <span id="view_can_start_from"></span></p>
         <p><strong>9–6 Available:</strong> <span id="view_available_9_to_6"></span></p>
         <p><strong>Telegram ID:</strong> <span id="view_telegram_id"></span></p>
@@ -189,6 +195,15 @@
           </div>
           <div class="tab-pane fade" id="tabDesign">
             <p><strong>Design Score:</strong> <span id="view_design_score"></span></p>
+          </div>
+          <div class="tab-pane fade" id="tabMeetings">
+            {% for i in range(1,6) %}
+            <p><strong>Meeting {{ i }}:</strong>
+              <span id="view_meeting{{ i }}_date"></span>,
+              <span id="view_meeting{{ i }}_day"></span>,
+              <span id="view_meeting{{ i }}_time"></span>
+            </p>
+            {% endfor %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- extend candidate data with a `status` field and five meeting slots
- display status in the candidate list and view modal
- allow editing status from the General tab
- add Meetings tab with five schedulable rows

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b1c9b7d48326ae1d8ba28d3d37e3