### PR TITLE
Add portfolio and previous work score fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ COLUMNS = [
     'exp_dashboard_b2b', 'exp_dynamic_reports', 'exp_role_based_access',
     'exp_pos_mobile', 'exp_data_sync', 'exp_multistep_forms',
     'exp_low_digital_users', 'exp_multilingual', 'exp_portfolio_relevant',
-    'interviewer_score', 'design_score', 'look_score', 'resume_file', 'total_score',
+    'interviewer_score', 'design_score', 'look_score', 'portfolio_score', 'previous_work_score', 'resume_file', 'total_score',
     'status',
     'meeting1_date', 'meeting1_day', 'meeting1_time',
     'meeting2_date', 'meeting2_day', 'meeting2_time',
@@ -131,7 +131,7 @@ def compute_total_score(row):
     if str(row.get('ok_with_task', '')) == 'Yes':
         score += 2
 
-    # interviewer, design, and look scores
+    # interviewer, design, look, portfolio and previous work scores
     try:
         score += float(row.get('interviewer_score', 0))
     except ValueError:
@@ -142,6 +142,14 @@ def compute_total_score(row):
         pass
     try:
         score += float(row.get('look_score', 0))
+    except ValueError:
+        pass
+    try:
+        score += float(row.get('portfolio_score', 0))
+    except ValueError:
+        pass
+    try:
+        score += float(row.get('previous_work_score', 0))
     except ValueError:
         pass
 
@@ -182,6 +190,7 @@ def add_candidate():
         'exp_pos_mobile':'', 'exp_data_sync':'', 'exp_multistep_forms':'',
         'exp_low_digital_users':'', 'exp_multilingual':'', 'exp_portfolio_relevant':'',
         'interviewer_score':'0', 'design_score':'0', 'look_score':'0',
+        'portfolio_score':'0', 'previous_work_score':'0',
         'resume_file': stored_resume, 'total_score':'',
         'status':'pending',
         'meeting1_date':'', 'meeting1_day':'', 'meeting1_time':'',

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -119,6 +119,14 @@
             </div>
           </div>
           <div class="col-md-3">
+            <label class="form-label">Portfolio Score</label>
+            <input name="portfolio_score" value="{{ candidate.portfolio_score or 0 }}" type="number" class="form-control">
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Previous Work Score</label>
+            <input name="previous_work_score" value="{{ candidate.previous_work_score or 0 }}" type="number" class="form-control">
+          </div>
+          <div class="col-md-3">
             <div class="form-check mt-4">
               <input name="ok_with_task" class="form-check-input" type="checkbox" value="Yes" {% if candidate.ok_with_task=='Yes' %}checked{% endif %}>
               <label class="form-check-label">Okay with Design Task?</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -179,6 +179,8 @@
         <p><strong>Location:</strong> <span id="view_location"></span></p>
         <p><strong>Interviewer Score:</strong> <span id="view_interviewer_score"></span></p>
         <p><strong>Look Score:</strong> <span id="view_look_score"></span></p>
+        <p><strong>Portfolio Score:</strong> <span id="view_portfolio_score"></span></p>
+        <p><strong>Previous Work Score:</strong> <span id="view_previous_work_score"></span></p>
         <p><strong>Total Score:</strong> <span id="view_total_score"></span></p>
       </div>
       <div class="tab-pane fade" id="tabExperience">


### PR DESCRIPTION
## Summary
- track candidate portfolio and previous work scores
- display the scores in the edit form and view modal
- include scores in the total score calculation

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b68602d48326b627db3a0c7e9084