### PR TITLE
Use side drawer to show candidate info

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -140,14 +140,12 @@
 </div>
 
 <!-- View Modal -->
-<div class="modal fade" id="viewModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Candidate Details</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
+<div class="offcanvas offcanvas-end" tabindex="-1" id="viewDrawer" aria-labelledby="viewDrawerLabel">
+  <div class="offcanvas-header">
+    <h5 id="viewDrawerLabel" class="offcanvas-title">Candidate Details</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+  </div>
+  <div class="offcanvas-body">
         <ul class="nav nav-tabs mb-3">
           <li class="nav-item">
             <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabGeneral">General Info</button>
@@ -211,7 +209,6 @@
       </div>
     </div>
   </div>
-</div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
@@ -277,8 +274,8 @@
             const el = document.getElementById('view_' + k);
             if (el) el.innerText = v || '-';
           });
-          new bootstrap.Modal(
-            document.getElementById('viewModal')
+          new bootstrap.Offcanvas(
+            document.getElementById('viewDrawer')
           ).show();
         });
     }


### PR DESCRIPTION
## Summary
- switch view popup to a Bootstrap offcanvas drawer
- open the drawer with JavaScript

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6880b7f8848c8326adaae50a1166d7f8