### PR TITLE
Add experience years and meetings

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -65,6 +65,10 @@
             <input name="major" value="{{ candidate.major }}" type="text" class="form-control">
           </div>
           <div class="col-md-3">
+            <label class="form-label">Years of Experience</label>
+            <input name="years_of_experience" value="{{ candidate.years_of_experience or 0 }}" type="number" class="form-control">
+          </div>
+          <div class="col-md-3">
             <label class="form-label">Military Status</label>
             <select name="military_status" class="form-select">
               <option value="">Select</option>
@@ -209,24 +213,8 @@
         </div>
       </div>
       <div class="tab-pane fade" id="tabMeetings">
-        <div class="row g-3">
-          {% for i in range(1,6) %}
-          <div class="col-12 d-flex align-items-end mb-2">
-            <div class="me-2">
-              <label class="form-label">Date {{ i }}</label>
-              <input type="text" name="meeting{{ i }}_date" value="{{ candidate['meeting' ~ i ~ '_date'] }}" class="form-control">
-            </div>
-            <div class="me-2">
-              <label class="form-label">Day</label>
-              <input type="text" name="meeting{{ i }}_day" value="{{ candidate['meeting' ~ i ~ '_day'] }}" class="form-control">
-            </div>
-            <div>
-              <label class="form-label">Time</label>
-              <input type="time" name="meeting{{ i }}_time" value="{{ candidate['meeting' ~ i ~ '_time'] }}" class="form-control">
-            </div>
-          </div>
-          {% endfor %}
-        </div>
+        <div id="meetingsContainer" class="row g-3"></div>
+        <button type="button" class="btn btn-secondary mt-2" id="addMeetingBtn">Add Meeting</button>
       </div>
     </div>
     <div class="mt-3">
@@ -237,5 +225,49 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const meetingsData = {{ candidate.meetings|default('[]')|tojson }};
+  const container = document.getElementById('meetingsContainer');
+  function addRow(data={}) {
+    const row = document.createElement('div');
+    row.className = 'col-12 d-flex align-items-end mb-2';
+    row.innerHTML = `
+      <div class="me-2">
+        <label class="form-label">Date</label>
+        <input type="text" name="meeting_date[]" class="form-control" value="${data.date || ''}">
+      </div>
+      <div class="me-2">
+        <label class="form-label">Day</label>
+        <select name="meeting_day[]" class="form-select">
+          <option value="">-</option>
+          ${['Saturday','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday'].map(d=>`<option ${data.day===d?'selected':''}>${d}</option>`).join('')}
+        </select>
+      </div>
+      <div class="me-2">
+        <label class="form-label">Time</label>
+        <input type="text" name="meeting_time[]" class="form-control" value="${data.time || ''}">
+      </div>
+      <div class="me-2">
+        <label class="form-label">Type</label>
+        <select name="meeting_location[]" class="form-select">
+          <option value="online" ${data.location==='online'?'selected':''}>online</option>
+          <option value="offline" ${data.location==='offline'?'selected':''}>offline</option>
+        </select>
+      </div>
+      <div class="me-2">
+        <label class="form-label">Status</label>
+        <select name="meeting_status[]" class="form-select">
+          <option value="calendered" ${data.status==='calendered'?'selected':''}>calendered</option>
+          <option value="attended" ${data.status==='attended'?'selected':''}>attended</option>
+          <option value="not attended" ${data.status==='not attended'?'selected':''}>not attended</option>
+          <option value="canceled" ${data.status==='canceled'?'selected':''}>canceled</option>
+        </select>
+      </div>`;
+    container.appendChild(row);
+  }
+  meetingsData.forEach(m => addRow(m));
+  for (let i=meetingsData.length; i<5; i++) addRow({});
+  document.getElementById('addMeetingBtn').addEventListener('click', () => addRow({}));
+</script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -170,6 +170,7 @@
         <p><strong>Major:</strong> <span id="view_major"></span></p>
         <p><strong>Military Status:</strong> <span id="view_military_status"></span></p>
         <p><strong>Job Status:</strong> <span id="view_job_status"></span></p>
+        <p><strong>Years of Experience:</strong> <span id="view_years_of_experience"></span></p>
         <p><strong>Status:</strong> <span id="view_status"></span></p>
         <p><strong>Start From:</strong> <span id="view_can_start_from"></span></p>
         <p><strong>9–6 Available:</strong> <span id="view_available_9_to_6"></span></p>
@@ -197,13 +198,7 @@
             <p><strong>Design Score:</strong> <span id="view_design_score"></span></p>
           </div>
           <div class="tab-pane fade" id="tabMeetings">
-            {% for i in range(1,6) %}
-            <p><strong>Meeting {{ i }}:</strong>
-              <span id="view_meeting{{ i }}_date"></span>,
-              <span id="view_meeting{{ i }}_day"></span>,
-              <span id="view_meeting{{ i }}_time"></span>
-            </p>
-            {% endfor %}
+            <div id="view_meetings_list"></div>
           </div>
         </div>
       </div>
@@ -271,8 +266,18 @@
         .then(res => res.json())
         .then(data => {
           Object.entries(data).forEach(([k, v]) => {
+            if (k === 'meetings') return;
             const el = document.getElementById('view_' + k);
             if (el) el.innerText = v || '-';
+          });
+          const list = document.getElementById('view_meetings_list');
+          list.innerHTML = '';
+          let meetings = [];
+          try { meetings = JSON.parse(data.meetings || '[]'); } catch(e) {}
+          meetings.forEach((m, idx) => {
+            const p = document.createElement('p');
+            p.textContent = `Meeting ${idx+1}: ${m.date || ''} ${m.day || ''} ${m.time || ''} ${m.location || ''} ${m.status || ''}`;
+            list.appendChild(p);
           });
           new bootstrap.Offcanvas(
             document.getElementById('viewDrawer')


### PR DESCRIPTION
## Summary
- include `years_of_experience` in data model and scoring
- store meeting details as a dynamic JSON list
- update edit page with experience years input and dynamic meeting rows
- render meetings dynamically in view modal

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b9d8336c83268cabc6e97021d729