### PR TITLE
Fix meeting add bug

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -226,7 +226,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-  const meetingsData = {{ candidate.meetings|default('[]')|tojson }};
+  const meetingsData = JSON.parse({{ candidate.meetings|default('[]')|tojson }});
   const container = document.getElementById('meetingsContainer');
   function addRow(data={}) {
     const row = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure candidate meetings JSON is parsed before use

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880c087fbe083268bae91a0fa011a02