### PR TITLE
Add Next.js frontend and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Resume Service
+
+This repository contains a Flask backend for managing candidate resumes and a Next.js frontend (using TypeScript and Material UI) for interacting with the data.
+
+## Prerequisites
+
+- Python 3.8+
+- Node.js 16+
+
+## Backend Setup
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Run the Flask server:
+   ```bash
+   python app.py
+   ```
+   The server listens on `http://localhost:5000`.
+
+## Frontend Setup
+
+1. Navigate to the `frontend` folder:
+   ```bash
+   cd frontend
+   ```
+2. Install Node dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the Next.js development server:
+   ```bash
+   npm run dev
+   ```
+   This will start the app on `http://localhost:3000`.
+
+The frontend fetches candidate data from the Flask backend using the `/api/candidates` endpoint.
+
+## Production Build
+
+To build the frontend for production, run:
+```bash
+npm run build
+npm start
+```
+
+## Usage
+
+- Access `http://localhost:3000` to view the candidate list rendered using Material UI components.
+- Use the backend endpoints defined in `app.py` to add, edit or delete candidates.
+

--- a/app.py
+++ b/app.py
@@ -185,6 +185,17 @@ def index():
     df['id'] = df['id'].astype(int)
     return render_template('index.html', candidates=df.to_dict(orient='records'))
 
+# API endpoint for frontend
+@app.route('/api/candidates', methods=['GET'])
+def api_candidates():
+    """Return all candidates as JSON."""
+    df = read_data()
+    for idx, row in df.iterrows():
+        df.at[idx, 'total_score'] = compute_total_score(row)
+    df['id'] = df['id'].astype(int)
+    result = json.loads(json.dumps(df.to_dict(orient='records'), default=str))
+    return jsonify(result)
+
 @app.route('/add', methods=['POST'])
 def add_candidate():
     data = request.form

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  trailingSlash: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "resume-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@mui/material": "latest",
+    "@emotion/react": "latest",
+    "@emotion/styled": "latest",
+    "@mui/icons-material": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import type {AppProps} from 'next/app';
+import Head from 'next/head';
+import {CssBaseline, ThemeProvider, createTheme} from '@mui/material';
+
+const theme = createTheme();
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  React.useEffect(() => {
+    const jssStyles = document.querySelector('#jss-server-side');
+    if (jssStyles && jssStyles.parentElement) {
+      jssStyles.parentElement.removeChild(jssStyles);
+    }
+  }, []);
+
+  return (
+    <React.Fragment>
+      <Head>
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
+      </Head>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </React.Fragment>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { Container, Typography, Table, TableHead, TableRow, TableCell, TableBody, CircularProgress, Link } from '@mui/material';
+
+interface Candidate {
+  id: number;
+  name: string;
+  mobile: string;
+  gender: string;
+  total_score: number;
+  resume_file: string;
+  status: string;
+}
+
+export default function Home() {
+  const [loading, setLoading] = useState(true);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/candidates')
+      .then(res => res.json())
+      .then(data => {
+        setCandidates(data);
+        setLoading(false);
+      });
+  }, []);
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Head>
+        <title>Candidate List</title>
+      </Head>
+      <Typography variant="h4" gutterBottom>
+        Candidate List
+      </Typography>
+      {loading ? (
+        <CircularProgress />
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Mobile</TableCell>
+              <TableCell>Gender</TableCell>
+              <TableCell>Total</TableCell>
+              <TableCell>Resume</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {candidates.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell>{c.name}</TableCell>
+                <TableCell>{c.mobile}</TableCell>
+                <TableCell>{c.gender}</TableCell>
+                <TableCell>{c.total_score}</TableCell>
+                <TableCell>
+                  {c.resume_file ? (
+                    <Link href={`http://localhost:5000/resumes/${c.resume_file}`}>Resume</Link>
+                  ) : (
+                    '-'
+                  )}
+                </TableCell>
+                <TableCell>{c.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Container>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- switch frontend to Next.js with TypeScript and Material UI
- expose `/api/candidates` endpoint from Flask backend
- provide example Next.js pages
- add README instructions for running the backend and frontend

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6884a28b763c8326845f6991a0eb1af0