### PR TITLE
Fix fetch error by enabling CORS

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify, send_from_directory
+from flask_cors import CORS
 import pandas as pd
 import os
 import json
@@ -68,6 +69,7 @@ COLUMNS = [
 ]
 
 app = Flask(__name__)
+CORS(app)
 
 # Path to Excel data file (placed alongside this script)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 pandas
 openpyxl
+flask-cors


### PR DESCRIPTION
## Summary
- enable CORS on the Flask backend so the Next.js frontend can access the API
- document flask-cors in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884aa796bcc8326a4f5b70d74f60d1e