### PR TITLE
Fix JSON NaN bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,7 +195,9 @@ def api_candidates():
     for idx, row in df.iterrows():
         df.at[idx, 'total_score'] = compute_total_score(row)
     df['id'] = df['id'].astype(int)
-    result = json.loads(json.dumps(df.to_dict(orient='records'), default=str))
+    # Replace NaN values with None so the JSON is valid
+    df = df.where(pd.notnull(df), None)
+    result = df.to_dict(orient='records')
     return jsonify(result)
 
 @app.route('/add', methods=['POST'])


### PR DESCRIPTION
## Summary
- ensure `/api/candidates` endpoint returns valid JSON

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884ab9e19808326a423b64664dfba60