### PR TITLE
Convert candidate list to MUI DataGrid

### DIFF
--- a/frontend/components/AddCandidateDialog.tsx
+++ b/frontend/components/AddCandidateDialog.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+} from '@mui/material';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onAdded: () => void;
+}
+
+export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
+  const [name, setName] = useState('');
+  const [mobile, setMobile] = useState('');
+  const [gender, setGender] = useState('Male');
+
+  const handleSubmit = async () => {
+    const form = new FormData();
+    form.append('name', name || '');
+    form.append('mobile', mobile || '');
+    form.append('gender', gender || '');
+    await fetch('http://localhost:5000/add', {
+      method: 'POST',
+      body: form,
+    });
+    setName('');
+    setMobile('');
+    setGender('Male');
+    onAdded();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>New Candidate</DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Mobile"
+          value={mobile}
+          onChange={(e) => setMobile(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          select
+          label="Gender"
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+          fullWidth
+        >
+          <MenuItem value="Male">Male</MenuItem>
+          <MenuItem value="Female">Female</MenuItem>
+        </TextField>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSubmit} variant="contained">Add</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "@mui/material": "latest",
     "@emotion/react": "latest",
     "@emotion/styled": "latest",
-    "@mui/icons-material": "latest"
+    "@mui/icons-material": "latest",
+    "@mui/x-data-grid": "latest"
   },
   "devDependencies": {
     "typescript": "latest",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,29 +1,67 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import { Container, Typography, Table, TableHead, TableRow, TableCell, TableBody, CircularProgress, Link } from '@mui/material';
+import {
+  Container,
+  Typography,
+  CircularProgress,
+  Button,
+  TextField,
+} from '@mui/material';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import AddCandidateDialog from '../components/AddCandidateDialog';
 
 interface Candidate {
   id: number;
   name: string;
   mobile: string;
   gender: string;
-  total_score: number;
-  resume_file: string;
+  total_score: number | null;
+  resume_file: string | null;
   status: string;
 }
 
 export default function Home() {
   const [loading, setLoading] = useState(true);
   const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
 
-  useEffect(() => {
+  const fetchData = () => {
+    setLoading(true);
     fetch('http://localhost:5000/api/candidates')
-      .then(res => res.json())
-      .then(data => {
+      .then((res) => res.json())
+      .then((data) => {
         setCandidates(data);
         setLoading(false);
       });
+  };
+
+  useEffect(() => {
+    fetchData();
   }, []);
+
+  const columns: GridColDef[] = [
+    { field: 'name', headerName: 'Name', flex: 1 },
+    { field: 'mobile', headerName: 'Mobile', flex: 1 },
+    { field: 'gender', headerName: 'Gender', flex: 1 },
+    { field: 'total_score', headerName: 'Total', type: 'number', flex: 1 },
+    {
+      field: 'resume_file',
+      headerName: 'Resume',
+      flex: 1,
+      renderCell: (params) =>
+        params.value ? (
+          <a href={`http://localhost:5000/resumes/${params.value}`}>Resume</a>
+        ) : (
+          '-'
+        ),
+    },
+    { field: 'status', headerName: 'Status', flex: 1 },
+  ];
+
+  const filtered = candidates.filter((c) =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  );
 
   return (
     <Container sx={{ mt: 4 }}>
@@ -33,40 +71,38 @@ export default function Home() {
       <Typography variant="h4" gutterBottom>
         Candidate List
       </Typography>
+      <Button variant="contained" onClick={() => setOpen(true)} sx={{ mb: 2 }}>
+        New Candidate
+      </Button>
+      <TextField
+        label="Search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        sx={{ mb: 2, ml: 2 }}
+      />
       {loading ? (
         <CircularProgress />
       ) : (
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Mobile</TableCell>
-              <TableCell>Gender</TableCell>
-              <TableCell>Total</TableCell>
-              <TableCell>Resume</TableCell>
-              <TableCell>Status</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {candidates.map((c) => (
-              <TableRow key={c.id}>
-                <TableCell>{c.name}</TableCell>
-                <TableCell>{c.mobile}</TableCell>
-                <TableCell>{c.gender}</TableCell>
-                <TableCell>{c.total_score}</TableCell>
-                <TableCell>
-                  {c.resume_file ? (
-                    <Link href={`http://localhost:5000/resumes/${c.resume_file}`}>Resume</Link>
-                  ) : (
-                    '-'
-                  )}
-                </TableCell>
-                <TableCell>{c.status}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <div style={{ height: 400, width: '100%' }}>
+          <DataGrid
+            rows={filtered.map((c) => ({
+              id: c.id,
+              name: c.name || '-',
+              mobile: c.mobile || '-',
+              gender: c.gender || '-',
+              total_score: c.total_score ?? 0,
+              resume_file: c.resume_file || '',
+              status: c.status || '-',
+            }))}
+            columns={columns}
+            pageSize={5}
+            rowsPerPageOptions={[5, 10]}
+            disableSelectionOnClick
+            autoHeight
+          />
+        </div>
       )}
+      <AddCandidateDialog open={open} onClose={() => setOpen(false)} onAdded={fetchData} />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- add `@mui/x-data-grid`
- add `AddCandidateDialog` component to create new candidates
- update the Next.js index page to use DataGrid with search, sort and pop-up dialog

## Testing
- `python -m py_compile app.py`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(not run due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6884b51e280c8326badbc3a43f66541a