### PR TITLE
Add MUI drawer view, edit page and resume upload

### DIFF
--- a/frontend/components/AddCandidateDialog.tsx
+++ b/frontend/components/AddCandidateDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogActions,
   TextField,
   MenuItem,
+  FormHelperText,
 } from '@mui/material';
 
 interface Props {
@@ -19,12 +20,22 @@ export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
   const [name, setName] = useState('');
   const [mobile, setMobile] = useState('');
   const [gender, setGender] = useState('Male');
+  const [resume, setResume] = useState<File | null>(null);
+  const [mobileError, setMobileError] = useState('');
 
   const handleSubmit = async () => {
+    if (!/^0\d{10}$/.test(mobile)) {
+      setMobileError('Mobile must start with 0 and be 11 digits');
+      return;
+    }
+    setMobileError('');
     const form = new FormData();
     form.append('name', name || '');
     form.append('mobile', mobile || '');
     form.append('gender', gender || '');
+    if (resume) {
+      form.append('resume', resume);
+    }
     await fetch('http://localhost:5000/add', {
       method: 'POST',
       body: form,
@@ -32,6 +43,7 @@ export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
     setName('');
     setMobile('');
     setGender('Male');
+    setResume(null);
     onAdded();
     onClose();
   };
@@ -51,6 +63,8 @@ export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
           value={mobile}
           onChange={(e) => setMobile(e.target.value)}
           fullWidth
+          error={!!mobileError}
+          helperText={mobileError}
         />
         <TextField
           select
@@ -62,6 +76,15 @@ export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
           <MenuItem value="Male">Male</MenuItem>
           <MenuItem value="Female">Female</MenuItem>
         </TextField>
+        <Button variant="outlined" component="label">
+          Upload Resume
+          <input
+            type="file"
+            hidden
+            onChange={(e) => setResume(e.target.files ? e.target.files[0] : null)}
+          />
+        </Button>
+        {resume && <FormHelperText>{resume.name}</FormHelperText>}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>

--- a/frontend/components/ViewDrawer.tsx
+++ b/frontend/components/ViewDrawer.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  Drawer,
+  Tabs,
+  Tab,
+  Box,
+  Typography,
+  Button,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+
+interface Candidate {
+  [key: string]: any;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  candidate: Candidate | null;
+}
+
+export default function ViewDrawer({ open, onClose, candidate }: Props) {
+  const [tab, setTab] = React.useState(0);
+  const router = useRouter();
+
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose} sx={{ width: 350 }}>
+      <Box sx={{ width: 350, p: 2 }} role="presentation">
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+          <Typography variant="h6">{candidate?.name}</Typography>
+          {candidate && (
+            <Button size="small" onClick={() => router.push(`/edit/${candidate.id}`)}>
+              Edit
+            </Button>
+          )}
+        </Box>
+        <Tabs
+          value={tab}
+          onChange={(_, v) => setTab(v)}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          <Tab label="General" />
+          <Tab label="Experience" />
+          <Tab label="Design" />
+          <Tab label="Meetings" />
+        </Tabs>
+        <Box sx={{ mt: 2 }}>
+          {tab === 0 && (
+            <Box>
+              <Typography>Mobile: {candidate?.mobile}</Typography>
+              <Typography>Gender: {candidate?.gender}</Typography>
+              <Typography>Status: {candidate?.status}</Typography>
+              {candidate?.resume_file && (
+                <Typography>
+                  <a
+                    href={`http://localhost:5000/resumes/${candidate.resume_file}`}
+                    target="_blank"
+                  >
+                    Resume
+                  </a>
+                </Typography>
+              )}
+            </Box>
+          )}
+          {tab === 1 && (
+            <Box>
+              <Typography>
+                Technical Notes: {candidate?.technical_experience_notes || '-'}
+              </Typography>
+            </Box>
+          )}
+          {tab === 2 && (
+            <Box>
+              <Typography>Design Score: {candidate?.design_score || '-'}</Typography>
+            </Box>
+          )}
+          {tab === 3 && (
+            <Box>
+              {candidate?.meetings_list?.length ? (
+                candidate.meetings_list.map((m: any, idx: number) => (
+                  <Typography key={idx}>{`${m.date} ${m.day} ${m.time} ${m.location} ${m.status}`}</Typography>
+                ))
+              ) : (
+                <Typography>No meetings</Typography>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Drawer>
+  );
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,7 +3,11 @@ import type {AppProps} from 'next/app';
 import Head from 'next/head';
 import {CssBaseline, ThemeProvider, createTheme} from '@mui/material';
 
-const theme = createTheme();
+const theme = createTheme({
+  typography: {
+    fontFamily: 'Vazirmatn, sans-serif',
+  },
+});
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   React.useEffect(() => {
@@ -17,6 +21,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     <React.Fragment>
       <Head>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap"
+        />
       </Head>
       <ThemeProvider theme={theme}>
         <CssBaseline />

--- a/frontend/pages/edit/[id].tsx
+++ b/frontend/pages/edit/[id].tsx
@@ -1,0 +1,109 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import {
+  Container,
+  TextField,
+  Typography,
+  Button,
+  CircularProgress,
+  Tabs,
+  Tab,
+  Box,
+} from '@mui/material';
+
+interface Candidate {
+  [key: string]: any;
+}
+
+export default function EditPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [candidate, setCandidate] = useState<Candidate | null>(null);
+  const [tab, setTab] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`http://localhost:5000/get/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setCandidate(data);
+        setLoading(false);
+      });
+  }, [id]);
+
+  const handleSave = async () => {
+    if (!candidate) return;
+    const form = new FormData();
+    Object.keys(candidate).forEach((key) => {
+      const val = candidate[key];
+      if (val !== undefined && val !== null) {
+        form.append(key, String(val));
+      }
+    });
+    await fetch(`http://localhost:5000/edit/${id}`, {
+      method: 'POST',
+      body: form,
+    });
+    router.push('/');
+  };
+
+  if (loading) return <CircularProgress />;
+  if (!candidate) return null;
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h5" gutterBottom>
+        Edit Candidate
+      </Typography>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="General" />
+        <Tab label="Experience" />
+      </Tabs>
+      {tab === 0 && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label="Name"
+            value={candidate.name || ''}
+            onChange={(e) => setCandidate({ ...candidate, name: e.target.value })}
+          />
+          <TextField
+            label="Mobile"
+            value={candidate.mobile || ''}
+            onChange={(e) =>
+              setCandidate({ ...candidate, mobile: e.target.value })
+            }
+          />
+          <TextField
+            label="Gender"
+            value={candidate.gender || ''}
+            onChange={(e) =>
+              setCandidate({ ...candidate, gender: e.target.value })
+            }
+          />
+        </Box>
+      )}
+      {tab === 1 && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label="Technical Notes"
+            value={candidate.technical_experience_notes || ''}
+            onChange={(e) =>
+              setCandidate({
+                ...candidate,
+                technical_experience_notes: e.target.value,
+              })
+            }
+            multiline
+          />
+        </Box>
+      )}
+      <Box sx={{ mt: 3 }}>
+        <Button variant="contained" onClick={handleSave} sx={{ mr: 1 }}>
+          Save
+        </Button>
+        <Button variant="outlined" onClick={() => router.push('/')}>Back</Button>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import AddCandidateDialog from '../components/AddCandidateDialog';
+import ViewDrawer from '../components/ViewDrawer';
 
 interface Candidate {
   id: number;
@@ -25,6 +26,8 @@ export default function Home() {
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selected, setSelected] = useState<Candidate | null>(null);
 
   const fetchData = () => {
     setLoading(true);
@@ -34,6 +37,20 @@ export default function Home() {
         setCandidates(data);
         setLoading(false);
       });
+  };
+
+  const openDrawer = async (id: number) => {
+    const res = await fetch(`http://localhost:5000/get/${id}`);
+    const data = await res.json();
+    if (data.meetings) {
+      try {
+        data.meetings_list = JSON.parse(data.meetings);
+      } catch {
+        data.meetings_list = [];
+      }
+    }
+    setSelected(data);
+    setDrawerOpen(true);
   };
 
   useEffect(() => {
@@ -57,6 +74,15 @@ export default function Home() {
         ),
     },
     { field: 'status', headerName: 'Status', flex: 1 },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      renderCell: (params) => (
+        <Button size="small" onClick={() => openDrawer(params.row.id)}>
+          View
+        </Button>
+      ),
+    },
   ];
 
   const filtered = candidates.filter((c) =>
@@ -103,6 +129,14 @@ export default function Home() {
         </div>
       )}
       <AddCandidateDialog open={open} onClose={() => setOpen(false)} onAdded={fetchData} />
+      <ViewDrawer
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+          setSelected(null);
+        }}
+        candidate={selected}
+      />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- add phone number validation and resume upload when creating candidates
- load Vazirmatn font globally
- add view drawer with tabs and edit link
- show actions column with drawer button
- implement simple edit page

## Testing
- `python -m py_compile app.py`
- `npm install` *(fails: 403 Forbidden due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68860a7e82888326af5c8054d853d57f