### PR TITLE
Expand edit form and drawer

### DIFF
--- a/frontend/components/ViewDrawer.tsx
+++ b/frontend/components/ViewDrawer.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Typography,
   Button,
+  Divider,
 } from '@mui/material';
 import { useRouter } from 'next/router';
 
@@ -24,8 +25,13 @@ export default function ViewDrawer({ open, onClose, candidate }: Props) {
   const router = useRouter();
 
   return (
-    <Drawer anchor="right" open={open} onClose={onClose} sx={{ width: 350 }}>
-      <Box sx={{ width: 350, p: 2 }} role="presentation">
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { width: 500 } }}
+    >
+      <Box sx={{ width: 500, p: 2 }} role="presentation">
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
           <Typography variant="h6">{candidate?.name}</Typography>
           {candidate && (
@@ -47,36 +53,60 @@ export default function ViewDrawer({ open, onClose, candidate }: Props) {
         </Tabs>
         <Box sx={{ mt: 2 }}>
           {tab === 0 && (
-            <Box>
-              <Typography>Mobile: {candidate?.mobile}</Typography>
-              <Typography>Gender: {candidate?.gender}</Typography>
-              <Typography>Status: {candidate?.status}</Typography>
+            <Box sx={{ '& > *': { mb: 1 } }}>
+              <Typography fontWeight="bold">Mobile: <span style={{ fontWeight: 400 }}>{candidate?.mobile}</span></Typography>
+              <Typography fontWeight="bold">Gender: <span style={{ fontWeight: 400 }}>{candidate?.gender}</span></Typography>
+              <Typography fontWeight="bold">Status: <span style={{ fontWeight: 400 }}>{candidate?.status}</span></Typography>
+              <Typography fontWeight="bold">Marital Status: <span style={{ fontWeight: 400 }}>{candidate?.marital_status || '-'}</span></Typography>
+              <Typography fontWeight="bold">Education: <span style={{ fontWeight: 400 }}>{candidate?.education || '-'}</span></Typography>
+              <Typography fontWeight="bold">Major: <span style={{ fontWeight: 400 }}>{candidate?.major || '-'}</span></Typography>
+              <Typography fontWeight="bold">Year of Birth: <span style={{ fontWeight: 400 }}>{candidate?.year_of_birth || '-'}</span></Typography>
+              <Typography fontWeight="bold">Source of News: <span style={{ fontWeight: 400 }}>{candidate?.source_of_news || '-'}</span></Typography>
+              <Typography fontWeight="bold">Military Status: <span style={{ fontWeight: 400 }}>{candidate?.military_status || '-'}</span></Typography>
+              <Typography fontWeight="bold">Job Status: <span style={{ fontWeight: 400 }}>{candidate?.job_status || '-'}</span></Typography>
+              <Typography fontWeight="bold">Years of Experience: <span style={{ fontWeight: 400 }}>{candidate?.years_of_experience || '-'}</span></Typography>
+              <Typography fontWeight="bold">Start From: <span style={{ fontWeight: 400 }}>{candidate?.can_start_from || '-'}</span></Typography>
+              <Typography fontWeight="bold">9-6 Available: <span style={{ fontWeight: 400 }}>{candidate?.available_9_to_6 || '-'}</span></Typography>
+              <Typography fontWeight="bold">Telegram ID: <span style={{ fontWeight: 400 }}>{candidate?.telegram_id || '-'}</span></Typography>
+              <Typography fontWeight="bold">Location: <span style={{ fontWeight: 400 }}>{candidate?.location || '-'}</span></Typography>
+              <Typography fontWeight="bold">Interviewer Score: <span style={{ fontWeight: 400 }}>{candidate?.interviewer_score || '-'}</span></Typography>
+              <Typography fontWeight="bold">Look Score: <span style={{ fontWeight: 400 }}>{candidate?.look_score || '-'}</span></Typography>
+              <Typography fontWeight="bold">Portfolio Score: <span style={{ fontWeight: 400 }}>{candidate?.portfolio_score || '-'}</span></Typography>
+              <Typography fontWeight="bold">Previous Work Score: <span style={{ fontWeight: 400 }}>{candidate?.previous_work_score || '-'}</span></Typography>
+              <Typography fontWeight="bold">Total Score: <span style={{ fontWeight: 400 }}>{candidate?.total_score || '-'}</span></Typography>
               {candidate?.resume_file && (
-                <Typography>
-                  <a
-                    href={`http://localhost:5000/resumes/${candidate.resume_file}`}
-                    target="_blank"
-                  >
-                    Resume
+                <Typography fontWeight="bold">
+                  Resume:{' '}
+                  <a href={`http://localhost:5000/resumes/${candidate.resume_file}`} target="_blank" rel="noreferrer">
+                    Download
                   </a>
                 </Typography>
               )}
             </Box>
           )}
           {tab === 1 && (
-            <Box>
-              <Typography>
-                Technical Notes: {candidate?.technical_experience_notes || '-'}
-              </Typography>
+            <Box sx={{ '& > *': { mb: 1 } }}>
+              <Typography fontWeight="bold">B2B Dashboard Exp: <span style={{ fontWeight: 400 }}>{candidate?.exp_dashboard_b2b || '-'}</span></Typography>
+              <Typography fontWeight="bold">Dynamic Reports: <span style={{ fontWeight: 400 }}>{candidate?.exp_dynamic_reports || '-'}</span></Typography>
+              <Typography fontWeight="bold">Role-Based UI: <span style={{ fontWeight: 400 }}>{candidate?.exp_role_based_access || '-'}</span></Typography>
+              <Typography fontWeight="bold">POS/Mobile Exp: <span style={{ fontWeight: 400 }}>{candidate?.exp_pos_mobile || '-'}</span></Typography>
+              <Typography fontWeight="bold">Data Sync: <span style={{ fontWeight: 400 }}>{candidate?.exp_data_sync || '-'}</span></Typography>
+              <Typography fontWeight="bold">Multi-step Forms: <span style={{ fontWeight: 400 }}>{candidate?.exp_multistep_forms || '-'}</span></Typography>
+              <Typography fontWeight="bold">Low-Literate Users: <span style={{ fontWeight: 400 }}>{candidate?.exp_low_digital_users || '-'}</span></Typography>
+              <Typography fontWeight="bold">Multilingual: <span style={{ fontWeight: 400 }}>{candidate?.exp_multilingual || '-'}</span></Typography>
+              <Typography fontWeight="bold">Portfolio Relevant: <span style={{ fontWeight: 400 }}>{candidate?.exp_portfolio_relevant || '-'}</span></Typography>
+              <Divider sx={{ my: 1 }} />
+              <Typography fontWeight="bold">Technical Notes:</Typography>
+              <Typography sx={{ ml: 1 }}>{candidate?.technical_experience_notes || '-'}</Typography>
             </Box>
           )}
           {tab === 2 && (
             <Box>
-              <Typography>Design Score: {candidate?.design_score || '-'}</Typography>
+              <Typography fontWeight="bold">Design Score: <span style={{ fontWeight: 400 }}>{candidate?.design_score || '-'}</span></Typography>
             </Box>
           )}
           {tab === 3 && (
-            <Box>
+            <Box sx={{ '& > *': { mb: 1 } }}>
               {candidate?.meetings_list?.length ? (
                 candidate.meetings_list.map((m: any, idx: number) => (
                   <Typography key={idx}>{`${m.date} ${m.day} ${m.time} ${m.location} ${m.status}`}</Typography>

--- a/frontend/pages/edit/[id].tsx
+++ b/frontend/pages/edit/[id].tsx
@@ -9,16 +9,30 @@ import {
   Tabs,
   Tab,
   Box,
+  MenuItem,
+  FormControlLabel,
+  Checkbox,
+  Divider,
 } from '@mui/material';
 
 interface Candidate {
   [key: string]: any;
 }
 
+interface Meeting {
+  date?: string;
+  day?: string;
+  time?: string;
+  location?: string;
+  status?: string;
+}
+
 export default function EditPage() {
   const router = useRouter();
   const { id } = router.query;
   const [candidate, setCandidate] = useState<Candidate | null>(null);
+  const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [resumeFile, setResumeFile] = useState<File | null>(null);
   const [tab, setTab] = useState(0);
   const [loading, setLoading] = useState(true);
 
@@ -27,10 +41,35 @@ export default function EditPage() {
     fetch(`http://localhost:5000/get/${id}`)
       .then((res) => res.json())
       .then((data) => {
+        let m: Meeting[] = [];
+        if (data.meetings) {
+          try {
+            m = JSON.parse(data.meetings);
+          } catch {
+            m = [];
+          }
+        }
+        if (m.length < 5) {
+          m = [...m, ...Array.from({ length: 5 - m.length }, () => ({}))];
+        }
+        setMeetings(m);
         setCandidate(data);
         setLoading(false);
       });
   }, [id]);
+
+  const updateField = (key: string, value: any) => {
+    if (!candidate) return;
+    setCandidate({ ...candidate, [key]: value });
+  };
+
+  const updateMeeting = (idx: number, key: keyof Meeting, value: string) => {
+    const updated = [...meetings];
+    updated[idx] = { ...updated[idx], [key]: value };
+    setMeetings(updated);
+  };
+
+  const addMeeting = () => setMeetings([...meetings, {}]);
 
   const handleSave = async () => {
     if (!candidate) return;
@@ -41,6 +80,16 @@ export default function EditPage() {
         form.append(key, String(val));
       }
     });
+    meetings.forEach((m) => {
+      form.append('meeting_date[]', m.date || '');
+      form.append('meeting_day[]', m.day || '');
+      form.append('meeting_time[]', m.time || '');
+      form.append('meeting_location[]', m.location || '');
+      form.append('meeting_status[]', m.status || '');
+    });
+    if (resumeFile) {
+      form.append('resume', resumeFile);
+    }
     await fetch(`http://localhost:5000/edit/${id}`, {
       method: 'POST',
       body: form,
@@ -59,43 +108,399 @@ export default function EditPage() {
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="General" />
         <Tab label="Experience" />
+        <Tab label="Design" />
+        <Tab label="Meetings" />
       </Tabs>
       {tab === 0 && (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            label="Name"
-            value={candidate.name || ''}
-            onChange={(e) => setCandidate({ ...candidate, name: e.target.value })}
-          />
-          <TextField
-            label="Mobile"
-            value={candidate.mobile || ''}
-            onChange={(e) =>
-              setCandidate({ ...candidate, mobile: e.target.value })
-            }
-          />
-          <TextField
-            label="Gender"
-            value={candidate.gender || ''}
-            onChange={(e) =>
-              setCandidate({ ...candidate, gender: e.target.value })
-            }
-          />
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <Typography fontWeight="bold" color="primary.main">
+            Personal Info
+          </Typography>
+          <Divider />
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            <TextField
+              label="Full Name"
+              value={candidate.name || ''}
+              onChange={(e) => updateField('name', e.target.value)}
+            />
+            <TextField
+              label="Mobile Number"
+              value={candidate.mobile || ''}
+              onChange={(e) => updateField('mobile', e.target.value)}
+            />
+            <TextField
+              select
+              label="Gender"
+              value={candidate.gender || ''}
+              onChange={(e) => updateField('gender', e.target.value)}
+            >
+              <MenuItem value="Male">Male</MenuItem>
+              <MenuItem value="Female">Female</MenuItem>
+            </TextField>
+            <TextField
+              label="Year of Birth"
+              type="number"
+              value={candidate.year_of_birth || ''}
+              onChange={(e) => updateField('year_of_birth', e.target.value)}
+            />
+          </Box>
+          <Typography fontWeight="bold" color="success.main">
+            Background
+          </Typography>
+          <Divider />
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            <TextField
+              select
+              label="Marital Status"
+              value={candidate.marital_status || ''}
+              onChange={(e) => updateField('marital_status', e.target.value)}
+            >
+              <MenuItem value="">Select</MenuItem>
+              <MenuItem value="Single">Single</MenuItem>
+              <MenuItem value="Married">Married</MenuItem>
+            </TextField>
+            <TextField
+              select
+              label="Education Level"
+              value={candidate.education || ''}
+              onChange={(e) => updateField('education', e.target.value)}
+            >
+              <MenuItem value="">Select</MenuItem>
+              <MenuItem value="Diploma">Diploma</MenuItem>
+              <MenuItem value="Bachelor">Bachelor</MenuItem>
+              <MenuItem value="Master">Master</MenuItem>
+            </TextField>
+            <TextField
+              label="Major / Field"
+              value={candidate.major || ''}
+              onChange={(e) => updateField('major', e.target.value)}
+            />
+            <TextField
+              label="Years of Experience"
+              type="number"
+              value={candidate.years_of_experience || ''}
+              onChange={(e) => updateField('years_of_experience', e.target.value)}
+            />
+            <TextField
+              select
+              label="Military Status"
+              value={candidate.military_status || ''}
+              onChange={(e) => updateField('military_status', e.target.value)}
+            >
+              <MenuItem value="">Select</MenuItem>
+              <MenuItem value="Completed">Completed</MenuItem>
+              <MenuItem value="Exempt">Exempt</MenuItem>
+              <MenuItem value="In Progress">In Progress</MenuItem>
+              <MenuItem value="N/A">N/A</MenuItem>
+            </TextField>
+            <TextField
+              select
+              label="Current Job Status"
+              value={candidate.job_status || ''}
+              onChange={(e) => updateField('job_status', e.target.value)}
+            >
+              <MenuItem value="">Select</MenuItem>
+              <MenuItem value="Employed">Employed</MenuItem>
+              <MenuItem value="Freelancer">Freelancer</MenuItem>
+              <MenuItem value="Unemployed">Unemployed</MenuItem>
+            </TextField>
+            <TextField
+              select
+              label="Status"
+              value={candidate.status || ''}
+              onChange={(e) => updateField('status', e.target.value)}
+            >
+              <MenuItem value="pending">pending</MenuItem>
+              <MenuItem value="called">called</MenuItem>
+              <MenuItem value="Online meeting">Online meeting</MenuItem>
+              <MenuItem value="offline meeting">offline meeting</MenuItem>
+              <MenuItem value="rejected">rejected</MenuItem>
+            </TextField>
+            <TextField
+              select
+              label="Can Start From"
+              value={candidate.can_start_from || ''}
+              onChange={(e) => updateField('can_start_from', e.target.value)}
+            >
+              <MenuItem value="">Select</MenuItem>
+              <MenuItem value="1 Week">1 Week</MenuItem>
+              <MenuItem value="Less than a month">Less than a month</MenuItem>
+              <MenuItem value="More than a month">More than a month</MenuItem>
+            </TextField>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.available_9_to_6 === 'Yes'}
+                  onChange={(e) =>
+                    updateField('available_9_to_6', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Okay with 9-6 Work?"
+            />
+            <TextField
+              label="Telegram ID"
+              value={candidate.telegram_id || ''}
+              onChange={(e) => updateField('telegram_id', e.target.value)}
+            />
+            <TextField
+              select
+              label="Source of News"
+              value={candidate.source_of_news || ''}
+              onChange={(e) => updateField('source_of_news', e.target.value)}
+            >
+              <MenuItem value="Linkedin">Linkedin</MenuItem>
+              <MenuItem value="Connections">Connections</MenuItem>
+              <MenuItem value="Jobinja">Jobinja</MenuItem>
+              <MenuItem value="Jobvision">Jobvision</MenuItem>
+            </TextField>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.has_portfolio === 'Yes'}
+                  onChange={(e) =>
+                    updateField('has_portfolio', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Has Portfolio?"
+            />
+            <TextField
+              label="Portfolio Score"
+              type="number"
+              value={candidate.portfolio_score || ''}
+              onChange={(e) => updateField('portfolio_score', e.target.value)}
+            />
+            <TextField
+              label="Previous Work Score"
+              type="number"
+              value={candidate.previous_work_score || ''}
+              onChange={(e) => updateField('previous_work_score', e.target.value)}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.ok_with_task === 'Yes'}
+                  onChange={(e) =>
+                    updateField('ok_with_task', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Okay with Design Task?"
+            />
+            <TextField
+              label="City / Area in Tehran"
+              value={candidate.location || ''}
+              onChange={(e) => updateField('location', e.target.value)}
+            />
+            <TextField
+              label="Interviewer Score"
+              type="number"
+              value={candidate.interviewer_score || ''}
+              onChange={(e) => updateField('interviewer_score', e.target.value)}
+            />
+            <TextField
+              label="Look Score"
+              type="number"
+              value={candidate.look_score || ''}
+              onChange={(e) => updateField('look_score', e.target.value)}
+            />
+            <Button variant="outlined" component="label">
+              Upload Resume
+              <input
+                type="file"
+                hidden
+                onChange={(e) =>
+                  setResumeFile(e.target.files ? e.target.files[0] : null)
+                }
+              />
+            </Button>
+            {candidate.resume_file && (
+              <Typography>
+                <a
+                  href={`http://localhost:5000/resumes/${candidate.resume_file}`}
+                  target="_blank"
+                >
+                  Current Resume
+                </a>
+              </Typography>
+            )}
+          </Box>
         </Box>
       )}
       {tab === 1 && (
+        <Box sx={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_dashboard_b2b === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_dashboard_b2b', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Designed B2B dashboards"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_dynamic_reports === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_dynamic_reports', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Dynamic reporting interfaces"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_role_based_access === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_role_based_access', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Role-based access UI"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_pos_mobile === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_pos_mobile', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="POS/mobile interfaces"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_data_sync === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_data_sync', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Syncing external data"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_multistep_forms === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_multistep_forms', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Multi-step forms"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_low_digital_users === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_low_digital_users', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Low-digital-literacy users"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_multilingual === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_multilingual', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Multilingual systems"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={candidate.exp_portfolio_relevant === 'Yes'}
+                  onChange={(e) =>
+                    updateField('exp_portfolio_relevant', e.target.checked ? 'Yes' : '')
+                  }
+                />
+              }
+              label="Portfolio has relevant work"
+            />
+          </Box>
+          <TextField
+            label="Other notes about technical fit"
+            multiline
+            rows={8}
+            sx={{ flex: 1, minWidth: 300 }}
+            value={candidate.technical_experience_notes || ''}
+            onChange={(e) => updateField('technical_experience_notes', e.target.value)}
+          />
+        </Box>
+      )}
+      {tab === 2 && (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           <TextField
-            label="Technical Notes"
-            value={candidate.technical_experience_notes || ''}
-            onChange={(e) =>
-              setCandidate({
-                ...candidate,
-                technical_experience_notes: e.target.value,
-              })
-            }
-            multiline
+            label="Design Score"
+            type="number"
+            value={candidate.design_score || ''}
+            onChange={(e) => updateField('design_score', e.target.value)}
           />
+        </Box>
+      )}
+      {tab === 3 && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {meetings.map((m, idx) => (
+            <Box key={idx} sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <TextField
+                label="Date"
+                value={m.date || ''}
+                onChange={(e) => updateMeeting(idx, 'date', e.target.value)}
+              />
+              <TextField
+                select
+                label="Day"
+                value={m.day || ''}
+                onChange={(e) => updateMeeting(idx, 'day', e.target.value)}
+              >
+                <MenuItem value="">-</MenuItem>
+                {['Saturday','Sunday','Monday','Tuesday','Wednesday','Thursday','Friday'].map((d) => (
+                  <MenuItem key={d} value={d}>{d}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Time"
+                value={m.time || ''}
+                onChange={(e) => updateMeeting(idx, 'time', e.target.value)}
+              />
+              <TextField
+                select
+                label="Type"
+                value={m.location || ''}
+                onChange={(e) => updateMeeting(idx, 'location', e.target.value)}
+              >
+                <MenuItem value="online">online</MenuItem>
+                <MenuItem value="offline">offline</MenuItem>
+              </TextField>
+              <TextField
+                select
+                label="Status"
+                value={m.status || ''}
+                onChange={(e) => updateMeeting(idx, 'status', e.target.value)}
+              >
+                <MenuItem value="calendered">calendered</MenuItem>
+                <MenuItem value="attended">attended</MenuItem>
+                <MenuItem value="not attended">not attended</MenuItem>
+                <MenuItem value="canceled">canceled</MenuItem>
+              </TextField>
+            </Box>
+          ))}
+          <Button variant="outlined" size="small" onClick={addMeeting}>
+            Add Meeting
+          </Button>
         </Box>
       )}
       <Box sx={{ mt: 3 }}>


### PR DESCRIPTION
## Summary
- implement full candidate form fields in Next.js edit page
- enhance drawer to show detailed info with better styling and increased width

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(failed: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68860c5c06b883269f23ec67fd4c1791