### PR TITLE
Add scoring weight API

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,9 @@ for the general categories such as education or availability.
    delete action appears as a trash bin icon.
 5. Use the **Add** button to register a new candidate in the selected list.
 
+### Scoring Weights API
+
+Use `/api/weights/<position>` to retrieve the total weight defined for a role in
+`scoring_config.json`.
+
 

--- a/scoring_config.json
+++ b/scoring_config.json
@@ -1,0 +1,12 @@
+{
+  "golang": {
+    "exp_grpc": 5,
+    "exp_microservices": 6,
+    "exp_unit_testing": 4
+  },
+  "product_designer": {
+    "exp_figma": 5,
+    "exp_user_research": 6,
+    "exp_prototyping": 4
+  }
+}


### PR DESCRIPTION
## Summary
- load scoring config from `scoring_config.json`
- provide `/api/weights/<position>` endpoint to return total weights for a role
- document endpoint in README
- include default scoring config for example roles

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68862d3ad7c48326a465701fd72c1e2f