### PR TITLE
Add admin settings page

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,6 +205,28 @@ def index():
     df['id'] = df['id'].astype(int)
     return render_template('index.html', candidates=df.to_dict(orient='records'))
 
+
+@app.route('/admin')
+def admin_page():
+    """Render admin settings page with current scoring config."""
+    config = load_scoring_config()
+    return render_template('admin.html', config=config)
+
+
+@app.route('/save_position', methods=['POST'])
+def save_position():
+    """Create or update a position and its score fields."""
+    data = request.get_json(force=True)
+    position = data.get('position')
+    scores = data.get('scores', {})
+    if not position or not isinstance(scores, dict):
+        return jsonify({'error': 'invalid data'}), 400
+    config = load_scoring_config()
+    config[position] = scores
+    with open(SCORING_CONFIG_FILE, 'w') as f:
+        json.dump(config, f, indent=2)
+    return jsonify({'status': 'ok'})
+
 # API endpoint for frontend
 @app.route('/api/candidates', methods=['GET'])
 def api_candidates():

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Settings</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="p-4">
+<div class="container">
+  <h3 class="mb-3">Admin Settings</h3>
+  <h5>Existing Positions</h5>
+  <ul>
+    {% for role, scores in config.items() %}
+    <li><strong>{{ role }}</strong>: {{ scores }}</li>
+    {% endfor %}
+  </ul>
+  <hr>
+  <h5>Add / Update Position</h5>
+  <div class="mb-3">
+    <label class="form-label">Position Name</label>
+    <input type="text" id="positionName" class="form-control">
+  </div>
+  <div id="scoresContainer"></div>
+  <button class="btn btn-secondary mb-3" id="addScoreBtn">Add Score Field</button>
+  <div>
+    <button class="btn btn-primary" id="saveBtn">Save Position</button>
+    <a href="/" class="btn btn-secondary">Back</a>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const container = document.getElementById('scoresContainer');
+  function addRow(name='', value='') {
+    const row = document.createElement('div');
+    row.className = 'row g-2 mb-2';
+    row.innerHTML = `
+      <div class="col"><input type="text" class="form-control" placeholder="Field" value="${name}"></div>
+      <div class="col"><input type="number" class="form-control" placeholder="Score" value="${value}"></div>
+      <div class="col-auto"><button class="btn btn-danger btn-sm remove">X</button></div>`;
+    row.querySelector('.remove').onclick = () => row.remove();
+    container.appendChild(row);
+  }
+  document.getElementById('addScoreBtn').onclick = () => addRow();
+  addRow();
+  document.getElementById('saveBtn').onclick = () => {
+    const position = document.getElementById('positionName').value.trim();
+    if (!position) return alert('Position name required');
+    const scores = {};
+    container.querySelectorAll('.row').forEach(r => {
+      const [f,v] = r.querySelectorAll('input');
+      if (f.value) scores[f.value] = parseFloat(v.value) || 0;
+    });
+    fetch('/save_position', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({position, scores})
+    }).then(res => {
+      if (res.ok) location.reload();
+      else res.text().then(t => alert(t));
+    });
+  };
+</script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,9 +14,12 @@
 <div class="container">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h3>Candidate List</h3>
-    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addCandidateModal">
-      + Add New Candidate
-    </button>
+    <div>
+      <a href="/admin" class="btn btn-secondary me-2">Admin Settings</a>
+      <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addCandidateModal">
+        + Add New Candidate
+      </button>
+    </div>
   </div>
 
   <!-- Search Field -->


### PR DESCRIPTION
## Summary
- add Admin Settings button on home page
- create new admin page
- implement routes to manage scoring configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68862f9eb08c83268f720ade0414a170