### PR TITLE
Add role-based candidate pages

### DIFF
--- a/frontend/components/AddCandidateDialog.tsx
+++ b/frontend/components/AddCandidateDialog.tsx
@@ -14,9 +14,10 @@ interface Props {
   open: boolean;
   onClose: () => void;
   onAdded: () => void;
+  position: string;
 }
 
-export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
+export default function AddCandidateDialog({ open, onClose, onAdded, position }: Props) {
   const [name, setName] = useState('');
   const [mobile, setMobile] = useState('');
   const [gender, setGender] = useState('Male');
@@ -33,10 +34,11 @@ export default function AddCandidateDialog({ open, onClose, onAdded }: Props) {
     form.append('name', name || '');
     form.append('mobile', mobile || '');
     form.append('gender', gender || '');
+    form.append('position_type', position);
     if (resume) {
       form.append('resume', resume);
     }
-    await fetch('http://localhost:5000/add', {
+    await fetch('http://localhost:5000/api/candidates', {
       method: 'POST',
       body: form,
     });

--- a/frontend/pages/[position]/candidates.tsx
+++ b/frontend/pages/[position]/candidates.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import {
+  Container,
+  Typography,
+  CircularProgress,
+  Button,
+  TextField,
+  IconButton,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import AddCandidateDialog from '../../components/AddCandidateDialog';
+import ViewDrawer from '../../components/ViewDrawer';
+
+interface Candidate {
+  id: number;
+  name: string;
+  mobile: string;
+  gender: string;
+  total_score: number | null;
+  resume_file: string | null;
+  status: string;
+}
+
+export default function CandidateList() {
+  const router = useRouter();
+  const { position } = router.query;
+  const [loading, setLoading] = useState(true);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selected, setSelected] = useState<Candidate | null>(null);
+
+  const fetchData = () => {
+    if (!position) return;
+    setLoading(true);
+    fetch(`http://localhost:5000/api/candidates?position=${position}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setCandidates(data);
+        setLoading(false);
+      });
+  };
+
+  const openDrawer = async (id: number) => {
+    const res = await fetch(`http://localhost:5000/get/${id}`);
+    const data = await res.json();
+    if (data.meetings) {
+      try {
+        data.meetings_list = JSON.parse(data.meetings);
+      } catch {
+        data.meetings_list = [];
+      }
+    }
+    setSelected(data);
+    setDrawerOpen(true);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [position]);
+
+  const columns: GridColDef[] = [
+    { field: 'name', headerName: 'Name', flex: 1 },
+    { field: 'mobile', headerName: 'Mobile', flex: 1 },
+    { field: 'gender', headerName: 'Gender', flex: 1 },
+    { field: 'total_score', headerName: 'Total', type: 'number', flex: 1 },
+    {
+      field: 'resume_file',
+      headerName: 'Resume',
+      flex: 1,
+      renderCell: (params) =>
+        params.value ? (
+          <a href={`http://localhost:5000/resumes/${params.value}`}>Resume</a>
+        ) : (
+          '-'
+        ),
+    },
+    { field: 'status', headerName: 'Status', flex: 1 },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      renderCell: (params) => (
+        <>
+          <IconButton
+            size="small"
+            onClick={() => openDrawer(params.row.id)}
+            aria-label="view"
+          >
+            <VisibilityIcon fontSize="inherit" />
+          </IconButton>
+          <IconButton
+            size="small"
+            onClick={() => router.push(`/edit/${params.row.id}`)}
+            aria-label="edit"
+          >
+            <EditIcon fontSize="inherit" />
+          </IconButton>
+        </>
+      ),
+    },
+  ];
+
+  const filtered = candidates.filter((c) =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Head>
+        <title>{position} Candidates</title>
+      </Head>
+      <Typography variant="h4" gutterBottom>
+        {position} Candidates
+      </Typography>
+      <Button variant="contained" onClick={() => setOpen(true)} sx={{ mb: 2 }}>
+        New Candidate
+      </Button>
+      <TextField
+        label="Search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        sx={{ mb: 2, ml: 2 }}
+      />
+      {loading ? (
+        <CircularProgress />
+      ) : (
+        <div style={{ height: 400, width: '100%' }}>
+          <DataGrid
+            rows={filtered.map((c) => ({
+              id: c.id,
+              name: c.name || '-',
+              mobile: c.mobile || '-',
+              gender: c.gender || '-',
+              total_score: c.total_score ?? 0,
+              resume_file: c.resume_file || '',
+              status: c.status || '-',
+            }))}
+            columns={columns}
+            pageSize={5}
+            rowsPerPageOptions={[5, 10]}
+            disableSelectionOnClick
+            autoHeight
+          />
+        </div>
+      )}
+      <AddCandidateDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onAdded={fetchData}
+        position={typeof position === 'string' ? position : ''}
+      />
+      <ViewDrawer
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+          setSelected(null);
+        }}
+        candidate={selected}
+      />
+    </Container>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,160 +1,47 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import { Container, Typography, CircularProgress, Button, Grid } from '@mui/material';
 import Head from 'next/head';
-import {
-  Container,
-  Typography,
-  CircularProgress,
-  Button,
-  TextField,
-  IconButton,
-} from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import VisibilityIcon from '@mui/icons-material/Visibility';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import AddCandidateDialog from '../components/AddCandidateDialog';
-import ViewDrawer from '../components/ViewDrawer';
-
-interface Candidate {
-  id: number;
-  name: string;
-  mobile: string;
-  gender: string;
-  total_score: number | null;
-  resume_file: string | null;
-  status: string;
-}
 
 export default function Home() {
   const router = useRouter();
+  const [positions, setPositions] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
-  const [candidates, setCandidates] = useState<Candidate[]>([]);
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selected, setSelected] = useState<Candidate | null>(null);
-
-  const fetchData = () => {
-    setLoading(true);
-    fetch('http://localhost:5000/api/candidates')
-      .then((res) => res.json())
-      .then((data) => {
-        setCandidates(data);
-        setLoading(false);
-      });
-  };
-
-  const openDrawer = async (id: number) => {
-    const res = await fetch(`http://localhost:5000/get/${id}`);
-    const data = await res.json();
-    if (data.meetings) {
-      try {
-        data.meetings_list = JSON.parse(data.meetings);
-      } catch {
-        data.meetings_list = [];
-      }
-    }
-    setSelected(data);
-    setDrawerOpen(true);
-  };
 
   useEffect(() => {
-    fetchData();
+    fetch('http://localhost:5000/api/positions')
+      .then((res) => res.json())
+      .then((data) => {
+        setPositions(data);
+        setLoading(false);
+      });
   }, []);
 
-  const columns: GridColDef[] = [
-    { field: 'name', headerName: 'Name', flex: 1 },
-    { field: 'mobile', headerName: 'Mobile', flex: 1 },
-    { field: 'gender', headerName: 'Gender', flex: 1 },
-    { field: 'total_score', headerName: 'Total', type: 'number', flex: 1 },
-    {
-      field: 'resume_file',
-      headerName: 'Resume',
-      flex: 1,
-      renderCell: (params) =>
-        params.value ? (
-          <a href={`http://localhost:5000/resumes/${params.value}`}>Resume</a>
-        ) : (
-          '-'
-        ),
-    },
-    { field: 'status', headerName: 'Status', flex: 1 },
-    {
-      field: 'actions',
-      headerName: 'Actions',
-      renderCell: (params) => (
-        <>
-          <IconButton
-            size="small"
-            onClick={() => openDrawer(params.row.id)}
-            aria-label="view"
-          >
-            <VisibilityIcon fontSize="inherit" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={() => router.push(`/edit/${params.row.id}`)}
-            aria-label="edit"
-          >
-            <EditIcon fontSize="inherit" />
-          </IconButton>
-        </>
-      ),
-    },
-  ];
-
-  const filtered = candidates.filter((c) =>
-    c.name.toLowerCase().includes(search.toLowerCase())
-  );
+  const goto = (pos: string) => {
+    router.push(`/${pos}/candidates`);
+  };
 
   return (
     <Container sx={{ mt: 4 }}>
       <Head>
-        <title>Candidate List</title>
+        <title>Select Position</title>
       </Head>
       <Typography variant="h4" gutterBottom>
-        Candidate List
+        Choose Position
       </Typography>
-      <Button variant="contained" onClick={() => setOpen(true)} sx={{ mb: 2 }}>
-        New Candidate
-      </Button>
-      <TextField
-        label="Search"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        sx={{ mb: 2, ml: 2 }}
-      />
       {loading ? (
         <CircularProgress />
       ) : (
-        <div style={{ height: 400, width: '100%' }}>
-          <DataGrid
-            rows={filtered.map((c) => ({
-              id: c.id,
-              name: c.name || '-',
-              mobile: c.mobile || '-',
-              gender: c.gender || '-',
-              total_score: c.total_score ?? 0,
-              resume_file: c.resume_file || '',
-              status: c.status || '-',
-            }))}
-            columns={columns}
-            pageSize={5}
-            rowsPerPageOptions={[5, 10]}
-            disableSelectionOnClick
-            autoHeight
-          />
-        </div>
+        <Grid container spacing={2}>
+          {positions.map((p) => (
+            <Grid item key={p}>
+              <Button variant="outlined" onClick={() => goto(p)}>
+                {p}
+              </Button>
+            </Grid>
+          ))}
+        </Grid>
       )}
-      <AddCandidateDialog open={open} onClose={() => setOpen(false)} onAdded={fetchData} />
-      <ViewDrawer
-        open={drawerOpen}
-        onClose={() => {
-          setDrawerOpen(false);
-          setSelected(null);
-        }}
-        candidate={selected}
-      />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- support position filtering in backend API
- expose scoring config and positions via new routes
- send selected position when creating candidates
- add home page position selector and role-specific candidate list

## Testing
- `python -m py_compile app.py`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886312a74ec832688b75c3c53b972ee