### PR TITLE
Implement new positions API and admin improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ npm start
 
 - Access `http://localhost:3000` to view the candidate list rendered using Material UI components.
 - Use the backend endpoints defined in `app.py` to add, edit or delete candidates.
+- The list of available positions can be retrieved via `GET /api/positions` which
+  returns an array of objects containing `id` and `name`.
 
 ## Candidate Types and Admin Area
 
@@ -76,11 +78,10 @@ score and meeting history.
 
 ### Technical Experience by Position
 
-Each position has its own set of technical experience questions. The default
-scoring for these questions lives in the backend (see `TECH_SCORES` in
-`app.py`). An admin interface allows these questions and their score values to
-be modified per position. This interface can also be used to adjust the scores
-for the general categories such as education or availability.
+Each position has its own set of technical experience questions which are stored
+in `scoring_config.json`. The admin interface allows these questions and their
+score values to be modified per position as well as the global scoring rules
+(education, availability, reviewer weights, etc.).
 
 ### Typical User Flow
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Container, Typography, CircularProgress, Button, Grid } from '@mui/material';
+import { Container, Typography, CircularProgress, Button, Grid, Box } from '@mui/material';
 import Head from 'next/head';
 
 export default function Home() {
   const router = useRouter();
-  const [positions, setPositions] = useState<string[]>([]);
+  interface Pos { id: string; name: string }
+  const [positions, setPositions] = useState<Pos[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -26,17 +27,18 @@ export default function Home() {
       <Head>
         <title>Select Position</title>
       </Head>
-      <Typography variant="h4" gutterBottom>
-        Choose Position
-      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h4">Choose Position</Typography>
+        <Button onClick={() => router.push('/admin')}>Admin</Button>
+      </Box>
       {loading ? (
         <CircularProgress />
       ) : (
         <Grid container spacing={2}>
           {positions.map((p) => (
-            <Grid item key={p}>
-              <Button variant="outlined" onClick={() => goto(p)}>
-                {p}
+            <Grid item key={p.id}>
+              <Button variant="outlined" onClick={() => goto(p.id)}>
+                {p.name}
               </Button>
             </Grid>
           ))}

--- a/scoring_config.json
+++ b/scoring_config.json
@@ -1,12 +1,34 @@
 {
-  "golang": {
-    "exp_grpc": 5,
-    "exp_microservices": 6,
-    "exp_unit_testing": 4
+  "positions": {
+    "golang": {
+      "name": "Golang Developer",
+      "experience": {
+        "exp_grpc": {"label": "gRPC services", "points": 5},
+        "exp_microservices": {"label": "Microservices", "points": 6},
+        "exp_unit_testing": {"label": "Unit Testing", "points": 4}
+      }
+    },
+    "designer": {
+      "name": "Product Designer",
+      "experience": {
+        "exp_figma": {"label": "Figma", "points": 4},
+        "exp_user_testing": {"label": "User Testing", "points": 6}
+      }
+    }
   },
-  "product_designer": {
-    "exp_figma": 5,
-    "exp_user_research": 6,
-    "exp_prototyping": 4
+  "global": {
+    "gender": {"male": -3, "female": 1},
+    "education": {"bachelor": 1, "master": 2},
+    "military_status": {"completed": 2, "exempt": 1, "in_progress": -4},
+    "job_status": {"unemployed": 1, "freelancer": 0, "employed": -1},
+    "availability": {"1_week": 5, "less_than_month": 2, "more_than_month": -5},
+    "reviewer_weights": {
+      "interview_score": 1,
+      "design_score": 1,
+      "look_score": 1,
+      "portfolio_score": 1,
+      "previous_work_score": 1
+    },
+    "exp_per_year": 5
   }
 }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -11,15 +11,19 @@
   <h3 class="mb-3">Admin Settings</h3>
   <h5>Existing Positions</h5>
   <ul>
-    {% for role, scores in config.items() %}
-    <li><strong>{{ role }}</strong>: {{ scores }}</li>
+    {% for pid, info in config.items() %}
+    <li><strong>{{ info.name }}</strong> ({{ pid }})</li>
     {% endfor %}
   </ul>
   <hr>
   <h5>Add / Update Position</h5>
   <div class="mb-3">
+    <label class="form-label">Position ID</label>
+    <input type="text" id="positionId" class="form-control" placeholder="golang">
+  </div>
+  <div class="mb-3">
     <label class="form-label">Position Name</label>
-    <input type="text" id="positionName" class="form-control">
+    <input type="text" id="positionName" class="form-control" placeholder="Golang Developer">
   </div>
   <div id="scoresContainer"></div>
   <button class="btn btn-secondary mb-3" id="addScoreBtn">Add Score Field</button>
@@ -31,12 +35,13 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
   const container = document.getElementById('scoresContainer');
-  function addRow(name='', value='') {
+  function addRow(key='', label='', pts='') {
     const row = document.createElement('div');
     row.className = 'row g-2 mb-2';
     row.innerHTML = `
-      <div class="col"><input type="text" class="form-control" placeholder="Field" value="${name}"></div>
-      <div class="col"><input type="number" class="form-control" placeholder="Score" value="${value}"></div>
+      <div class="col"><input type="text" class="form-control" placeholder="Key" value="${key}"></div>
+      <div class="col"><input type="text" class="form-control" placeholder="Label" value="${label}"></div>
+      <div class="col"><input type="number" class="form-control" placeholder="Points" value="${pts}"></div>
       <div class="col-auto"><button class="btn btn-danger btn-sm remove">X</button></div>`;
     row.querySelector('.remove').onclick = () => row.remove();
     container.appendChild(row);
@@ -44,17 +49,18 @@
   document.getElementById('addScoreBtn').onclick = () => addRow();
   addRow();
   document.getElementById('saveBtn').onclick = () => {
-    const position = document.getElementById('positionName').value.trim();
-    if (!position) return alert('Position name required');
-    const scores = {};
+    const id = document.getElementById('positionId').value.trim();
+    const name = document.getElementById('positionName').value.trim();
+    if (!id || !name) return alert('ID and name required');
+    const experience = {};
     container.querySelectorAll('.row').forEach(r => {
-      const [f,v] = r.querySelectorAll('input');
-      if (f.value) scores[f.value] = parseFloat(v.value) || 0;
+      const [k,l,p] = r.querySelectorAll('input');
+      if (k.value) experience[k.value] = { label: l.value || k.value, points: parseFloat(p.value) || 0 };
     });
     fetch('/save_position', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({position, scores})
+      body: JSON.stringify({id, name, experience})
     }).then(res => {
       if (res.ok) location.reload();
       else res.text().then(t => alert(t));


### PR DESCRIPTION
## Summary
- restructure `scoring_config.json` to store position info and global rules
- compute scores based on new config
- expose positions with names via `/api/positions`
- expose position and global scoring via new endpoints
- update admin template to edit positions using new format
- enhance landing page with Admin button and named positions

## Testing
- `python -m py_compile app.py`
- `npx -y tsc -p frontend/tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_688635cc104c8326af8664d5694c507d