### PR TITLE
Add position management pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,6 +193,25 @@ def admin_page():
     )
 
 
+@app.route('/admin/position/<pos_id>', methods=['GET'])
+def position_form(pos_id):
+    """Page for adding or editing a single position."""
+    config = load_scoring_config()
+    positions = config.get('positions', {})
+    data = {'id': '', 'name': '', 'experience': {}}
+    if pos_id != 'new':
+        pos = positions.get(pos_id)
+        if not pos:
+            return redirect(url_for('admin_page'))
+        data['id'] = pos_id
+        data['name'] = pos.get('name', pos_id)
+        data['experience'] = pos.get('experience', {})
+    else:
+        data['id'] = ''
+        data['name'] = request.args.get('name', '')
+    return render_template('position_form.html', position=data)
+
+
 @app.route('/save_position', methods=['POST'])
 def save_position():
     """Create or update a position and its score fields."""

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -20,27 +20,18 @@
   </ul>
   <div class="tab-content mt-3">
     <div class="tab-pane fade show active" id="positions" role="tabpanel">
-      <h5>Existing Positions</h5>
-      <ul>
+      <div class="d-flex justify-content-between align-items-center">
+        <h5>Existing Positions</h5>
+        <button class="btn btn-primary" id="addPositionBtn">Add Position</button>
+      </div>
+      <ul class="mt-3">
         {% for pid, info in positions.items() %}
-        <li><strong>{{ info.name }}</strong> ({{ pid }})</li>
+        <li>
+          <strong>{{ info.name }}</strong> ({{ pid }})
+          <a href="/admin/position/{{ pid }}" class="btn btn-sm btn-secondary ms-2">Edit</a>
+        </li>
         {% endfor %}
       </ul>
-      <hr>
-      <h5>Add / Update Position</h5>
-      <div class="mb-3">
-        <label class="form-label">Position ID</label>
-        <input type="text" id="positionId" class="form-control" placeholder="golang">
-      </div>
-      <div class="mb-3">
-        <label class="form-label">Position Name</label>
-        <input type="text" id="positionName" class="form-control" placeholder="Golang Developer">
-      </div>
-      <div id="scoresContainer"></div>
-      <button class="btn btn-secondary mb-3" id="addScoreBtn">Add Score Field</button>
-      <div>
-        <button class="btn btn-primary" id="saveBtn">Save Position</button>
-      </div>
     </div>
     <div class="tab-pane fade" id="global" role="tabpanel">
       <h5>Global Scoring Configuration</h5>
@@ -53,38 +44,14 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-  // Position handling
-  const container = document.getElementById('scoresContainer');
-  function addRow(key='', label='', pts='') {
-    const row = document.createElement('div');
-    row.className = 'row g-2 mb-2';
-    row.innerHTML = `<div class="col"><input type="text" class="form-control" placeholder="Key" value="${key}"></div>
-      <div class="col"><input type="text" class="form-control" placeholder="Label" value="${label}"></div>
-      <div class="col"><input type="number" class="form-control" placeholder="Points" value="${pts}"></div>
-      <div class="col-auto"><button class="btn btn-danger btn-sm remove">X</button></div>`;
-    row.querySelector('.remove').onclick = () => row.remove();
-    container.appendChild(row);
-  }
-  document.getElementById('addScoreBtn').onclick = () => addRow();
-  addRow();
-  document.getElementById('saveBtn').onclick = () => {
-    const id = document.getElementById('positionId').value.trim();
-    const name = document.getElementById('positionName').value.trim();
-    if (!id || !name) return alert('ID and name required');
-    const experience = {};
-    container.querySelectorAll('.row').forEach(r => {
-      const [k,l,p] = r.querySelectorAll('input');
-      if (k.value) experience[k.value] = { label: l.value || k.value, points: parseFloat(p.value) || 0 };
-    });
-    fetch('/save_position', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({id, name, experience})
-    }).then(res => {
-      if (res.ok) location.reload();
-      else res.text().then(t => alert(t));
-    });
-  };
+  // Add position button
+  const addBtn = document.getElementById('addPositionBtn');
+  addBtn.addEventListener('click', () => {
+    const name = prompt('Position name?');
+    if (!name) return;
+    const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+    window.location = `/admin/position/${id}?name=${encodeURIComponent(name)}`;
+  });
 
   // Global config handling
   document.getElementById('saveGlobalBtn').onclick = () => {

--- a/templates/position_form.html
+++ b/templates/position_form.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Position Settings</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="p-4">
+<div class="container">
+  <h3 class="mb-3">{{ 'Edit' if position.id else 'Add' }} Position</h3>
+  <div class="mb-3">
+    <label class="form-label">Position ID</label>
+    <input type="text" id="positionId" class="form-control" value="{{ position.id }}" {% if position.id %}readonly{% endif %}>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Position Name</label>
+    <input type="text" id="positionName" class="form-control" value="{{ position.name }}">
+  </div>
+  <h5 class="mt-4">Experience Items</h5>
+  <div id="scoresContainer"></div>
+  <button class="btn btn-secondary mb-3" id="addScoreBtn">Add Row</button>
+  <div>
+    <button class="btn btn-primary" id="saveBtn">Save</button>
+    <a href="/admin" class="btn btn-secondary ms-2">Back</a>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const container = document.getElementById('scoresContainer');
+  function addRow(key='', label='', pts='') {
+    const row = document.createElement('div');
+    row.className = 'row g-2 mb-2';
+    row.innerHTML = `<div class="col"><input type="text" class="form-control" placeholder="Key" value="${key}"></div>`+
+      `<div class="col"><input type="text" class="form-control" placeholder="Label" value="${label}"></div>`+
+      `<div class="col"><input type="number" class="form-control" placeholder="Points" value="${pts}"></div>`+
+      `<div class="col-auto"><button class="btn btn-danger btn-sm remove">X</button></div>`;
+    row.querySelector('.remove').onclick = () => row.remove();
+    container.appendChild(row);
+  }
+  document.getElementById('addScoreBtn').onclick = () => addRow();
+  const existing = {{ position.experience | tojson }};
+  const keys = Object.keys(existing);
+  if (keys.length) {
+    keys.forEach(k => {
+      const item = existing[k];
+      addRow(k, item.label || k, item.points || 0);
+    });
+  } else {
+    addRow();
+  }
+  document.getElementById('saveBtn').onclick = () => {
+    const id = document.getElementById('positionId').value.trim();
+    const name = document.getElementById('positionName').value.trim();
+    if (!id || !name) { alert('ID and name required'); return; }
+    const experience = {};
+    container.querySelectorAll('.row').forEach(r => {
+      const [k,l,p] = r.querySelectorAll('input');
+      if (k.value) experience[k.value] = { label: l.value || k.value, points: parseFloat(p.value) || 0 };
+    });
+    fetch('/save_position', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({id, name, experience})
+    }).then(res => {
+      if (res.ok) window.location = '/admin';
+      else res.text().then(t => alert(t));
+    });
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated page to add/edit a position experience items
- simplify admin page to list positions with Add button
- allow navigation to `/admin/position/<id>` for editing
- keep global settings editing tab

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887214e34d0832699aad9fd26eacd10