### PR TITLE
Enhance home page and scoring details

### DIFF
--- a/frontend/components/ScoreBreakdown.tsx
+++ b/frontend/components/ScoreBreakdown.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, Table, TableBody, TableCell, TableRow } from '@mui/material';
+
+interface Candidate {
+  [key: string]: any;
+}
+
+interface ScoreItem {
+  label: string;
+  value: any;
+  points: number;
+}
+
+interface Props {
+  candidate: Candidate | null;
+}
+
+export default function ScoreBreakdown({ candidate }: Props) {
+  const [items, setItems] = useState<ScoreItem[]>([]);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    if (!candidate) return;
+    async function calc() {
+      const role = String(candidate.position_type || '').toLowerCase();
+      const [posRes, globalRes] = await Promise.all([
+        fetch(`http://localhost:5000/api/scoring/${role}`).then(r => r.json()),
+        fetch('http://localhost:5000/api/scoring/global').then(r => r.json()),
+      ]);
+      const list: ScoreItem[] = [];
+      let score = 0;
+      const add = (label: string, value: any, pts: number) => {
+        list.push({ label, value, points: pts });
+        score += pts;
+      };
+      const mapScore = (field: string, value: any) => {
+        const map = (globalRes as any)[field] || {};
+        const key = String(value).toLowerCase().replace(/\s+/g, '_');
+        const pts = Number(map[key] || 0);
+        add(field.replace(/_/g, ' '), value || '-', pts);
+      };
+
+      mapScore('gender', candidate.gender);
+      mapScore('education', candidate.education);
+      mapScore('military_status', candidate.military_status);
+      mapScore('job_status', candidate.job_status);
+      mapScore('availability', candidate.can_start_from);
+
+      if (String(candidate.available_9_to_6).toLowerCase() === 'yes') {
+        add('Available 9-6', 'Yes', 5);
+      }
+      if (String(candidate.has_portfolio).toLowerCase() === 'yes') {
+        add('Has portfolio', 'Yes', 5);
+      }
+      if (String(candidate.ok_with_task).toLowerCase() === 'yes') {
+        add('Ok with task', 'Yes', 2);
+      }
+
+      const weights = (globalRes as any).reviewer_weights || {};
+      ['interviewer_score', 'design_score', 'look_score', 'portfolio_score', 'previous_work_score'].forEach((f) => {
+        const val = parseFloat(candidate[f] ?? 0);
+        const w = parseFloat(weights[f] ?? 1);
+        const pts = val * w;
+        add(f.replace(/_/g, ' '), val, pts);
+      });
+
+      const years = parseFloat(candidate.years_of_experience ?? 0);
+      const perYear = parseFloat((globalRes as any).exp_per_year ?? 0);
+      if (!isNaN(years) && !isNaN(perYear)) {
+        add('Experience years', years, years * perYear);
+      }
+
+      const exp = (posRes as any).experience || {};
+      Object.entries(exp).forEach(([field, info]) => {
+        const val = String(candidate[field] || '');
+        const pts = val === 'Yes' ? Number((info as any).points || 0) : 0;
+        add((info as any).label || field, val || '-', pts);
+      });
+
+      setItems(list);
+      setTotal(score);
+    }
+    calc();
+  }, [candidate]);
+
+  if (!candidate) return null;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+        Score Breakdown
+      </Typography>
+      <Table size="small">
+        <TableBody>
+          {items.map((it, idx) => (
+            <TableRow key={idx}>
+              <TableCell>{it.label}</TableCell>
+              <TableCell>{String(it.value)}</TableCell>
+              <TableCell align="right">{it.points}</TableCell>
+            </TableRow>
+          ))}
+          <TableRow>
+            <TableCell colSpan={2} sx={{ fontWeight: 'bold' }}>
+              Total
+            </TableCell>
+            <TableCell align="right" sx={{ fontWeight: 'bold' }}>
+              {total}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/frontend/components/ViewDrawer.tsx
+++ b/frontend/components/ViewDrawer.tsx
@@ -9,6 +9,7 @@ import {
   Divider,
 } from '@mui/material';
 import { useRouter } from 'next/router';
+import ScoreBreakdown from './ScoreBreakdown';
 
 interface Candidate {
   [key: string]: any;
@@ -82,6 +83,8 @@ export default function ViewDrawer({ open, onClose, candidate }: Props) {
                   </a>
                 </Typography>
               )}
+              <Divider sx={{ my: 1 }} />
+              <ScoreBreakdown candidate={candidate} />
             </Box>
           )}
           {tab === 1 && (

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Container, Typography, CircularProgress, Button, Grid, Box } from '@mui/material';
+import {
+  Container,
+  Typography,
+  CircularProgress,
+  Button,
+  Grid,
+  Box,
+  Card,
+  CardContent,
+  CardActions,
+} from '@mui/material';
 import Head from 'next/head';
 
 export default function Home() {
@@ -8,14 +18,25 @@ export default function Home() {
   interface Pos { id: string; name: string }
   const [positions, setPositions] = useState<Pos[]>([]);
   const [loading, setLoading] = useState(true);
+  const [stats, setStats] = useState<Record<string, {count: number; exp: number}>>({});
 
   useEffect(() => {
-    fetch('http://localhost:5000/api/positions')
-      .then((res) => res.json())
-      .then((data) => {
-        setPositions(data);
-        setLoading(false);
-      });
+    async function load() {
+      const res = await fetch('http://localhost:5000/api/positions');
+      const data = await res.json();
+      setPositions(data);
+      const st: Record<string, {count:number; exp:number}> = {};
+      for (const p of data) {
+        const [candRes, scRes] = await Promise.all([
+          fetch(`http://localhost:5000/api/candidates?position=${p.id}`).then(r => r.json()),
+          fetch(`http://localhost:5000/api/scoring/${p.id}`).then(r => r.json()),
+        ]);
+        st[p.id] = { count: candRes.length, exp: Object.keys(scRes.experience || {}).length };
+      }
+      setStats(st);
+      setLoading(false);
+    }
+    load();
   }, []);
 
   const goto = (pos: string) => {
@@ -36,10 +57,28 @@ export default function Home() {
       ) : (
         <Grid container spacing={2}>
           {positions.map((p) => (
-            <Grid item key={p.id}>
-              <Button variant="outlined" onClick={() => goto(p.id)}>
-                {p.name}
-              </Button>
+            <Grid item key={p.id} xs={12} sm={6} md={4}>
+              <Card sx={{ minWidth: 200 }}>
+                <CardContent>
+                  <Typography variant="h6" gutterBottom>
+                    {p.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    ID: {p.id}
+                  </Typography>
+                  <Typography variant="body2">
+                    Candidates: {stats[p.id]?.count ?? 0}
+                  </Typography>
+                  <Typography variant="body2">
+                    Experience Items: {stats[p.id]?.exp ?? 0}
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button size="small" onClick={() => goto(p.id)}>
+                    View Candidates
+                  </Button>
+                </CardActions>
+              </Card>
             </Grid>
           ))}
         </Grid>


### PR DESCRIPTION
## Summary
- add ScoreBreakdown component showing candidate scoring factors
- show scoring breakdown in candidate drawer
- modernize home page with cards showing candidate counts

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6887287d7ddc8326936e82b6776e2163