### PR TITLE
Improve UI and navigation

### DIFF
--- a/frontend/pages/[position]/candidates.tsx
+++ b/frontend/pages/[position]/candidates.tsx
@@ -114,18 +114,20 @@ export default function CandidateList() {
       <Head>
         <title>{position} Candidates</title>
       </Head>
-      <Typography variant="h4" gutterBottom>
-        {position} Candidates
-      </Typography>
-      <Button variant="contained" onClick={() => setOpen(true)} sx={{ mb: 2 }}>
-        New Candidate
-      </Button>
-      <TextField
-        label="Search"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        sx={{ mb: 2, ml: 2 }}
-      />
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h4">{position} Candidates</Typography>
+        <Button variant="outlined" onClick={() => router.push('/')}>Back</Button>
+      </Box>
+      <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', mb: 2 }}>
+        <Button variant="contained" onClick={() => setOpen(true)}>
+          New Candidate
+        </Button>
+        <TextField
+          label="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </Box>
       {loading ? (
         <CircularProgress />
       ) : (

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -30,9 +30,10 @@ export default function AdminPage() {
       <Head>
         <title>Admin</title>
       </Head>
-      <Typography variant="h4" gutterBottom>
-        Positions
-      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h4">Positions</Typography>
+        <Button variant="outlined" onClick={() => router.push('/')}>Back</Button>
+      </Box>
       <Button
         variant="contained"
         onClick={() => router.push('/admin/position/new')}

--- a/frontend/pages/admin/position/[id].tsx
+++ b/frontend/pages/admin/position/[id].tsx
@@ -161,9 +161,12 @@ export default function PositionForm() {
       <Head>
         <title>Position Settings</title>
       </Head>
-      <Typography variant="h5" gutterBottom>
-        {id === 'new' ? 'Add Position' : 'Edit Position'}
-      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h5">
+          {id === 'new' ? 'Add Position' : 'Edit Position'}
+        </Typography>
+        <Button variant="outlined" onClick={() => router.push('/admin')}>Back</Button>
+      </Box>
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="General Score" />
         <Tab label="Experience" />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -44,23 +44,32 @@ export default function Home() {
   };
 
   return (
-    <Container sx={{ mt: 4 }}>
+    <Container maxWidth="md" sx={{ py: 5 }}>
       <Head>
         <title>Select Position</title>
       </Head>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-        <Typography variant="h4">Choose Position</Typography>
-        <Button onClick={() => router.push('/admin')}>Admin</Button>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 4, alignItems: 'center' }}>
+        <Box>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Welcome to Candidate Manager
+          </Typography>
+          <Typography color="text.secondary">
+            Choose a position to manage its candidates
+          </Typography>
+        </Box>
+        <Button variant="contained" onClick={() => router.push('/admin')}>
+          Admin
+        </Button>
       </Box>
       {loading ? (
         <CircularProgress />
       ) : (
-        <Grid container spacing={2}>
+        <Grid container spacing={3}>
           {positions.map((p) => (
             <Grid item key={p.id} xs={12} sm={6} md={4}>
-              <Card sx={{ minWidth: 200 }}>
+              <Card sx={{ minWidth: 220, bgcolor: 'grey.100', boxShadow: 3 }}>
                 <CardContent>
-                  <Typography variant="h6" gutterBottom>
+                  <Typography variant="h6" sx={{ mb: 1 }}>
                     {p.name}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
@@ -69,12 +78,12 @@ export default function Home() {
                   <Typography variant="body2">
                     Candidates: {stats[p.id]?.count ?? 0}
                   </Typography>
-                  <Typography variant="body2">
+                  <Typography variant="body2" gutterBottom>
                     Experience Items: {stats[p.id]?.exp ?? 0}
                   </Typography>
                 </CardContent>
                 <CardActions>
-                  <Button size="small" onClick={() => goto(p.id)}>
+                  <Button variant="contained" size="small" onClick={() => goto(p.id)}>
                     View Candidates
                   </Button>
                 </CardActions>


### PR DESCRIPTION
## Summary
- polish home page with hero text and colors
- add back buttons for easier navigation
- tidy spacing on candidate page and admin pages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found after install failure)*

------
https://chatgpt.com/codex/tasks/task_e_688743e68cac8326bbb2f9197c6b9bad