### PR TITLE
Implement theme and layout with dark mode

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { AppBar, Toolbar, Typography, Button, IconButton, Box } from '@mui/material';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
+
+interface Props {
+  children: ReactNode;
+  darkMode: boolean;
+  toggleDarkMode: () => void;
+}
+
+export default function Layout({ children, darkMode, toggleDarkMode }: Props) {
+  return (
+    <Box>
+      <AppBar position="static" color="primary">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Candidate Manager
+          </Typography>
+          <Button color="inherit" component={Link} href="/">
+            Home
+          </Button>
+          <Button color="inherit" component={Link} href="/admin">
+            Admin
+          </Button>
+          <IconButton color="inherit" onClick={toggleDarkMode} sx={{ ml: 1 }}>
+            {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Box component="main">{children}</Box>
+      <Box component="footer" sx={{ textAlign: 'center', py: 1, fontSize: '0.8rem' }}>
+        © {new Date().getFullYear()}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/pages/[position]/candidates.tsx
+++ b/frontend/pages/[position]/candidates.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   TextField,
   IconButton,
+  Box,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -110,7 +111,7 @@ export default function CandidateList() {
   );
 
   return (
-    <Container sx={{ mt: 4 }}>
+    <Container sx={{ mt: 4 }} maxWidth="xl" disableGutters>
       <Head>
         <title>{position} Candidates</title>
       </Head>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,15 +1,40 @@
 import * as React from 'react';
 import type {AppProps} from 'next/app';
 import Head from 'next/head';
-import {CssBaseline, ThemeProvider, createTheme} from '@mui/material';
+import {
+  CssBaseline,
+  ThemeProvider,
+  createTheme,
+  PaletteMode,
+} from '@mui/material';
+import Layout from '../components/Layout';
 
-const theme = createTheme({
-  typography: {
-    fontFamily: 'Vazirmatn, sans-serif',
-  },
-});
+const getTheme = (mode: PaletteMode) =>
+  createTheme({
+    palette: {
+      mode,
+      primary: { main: '#F7A043' },
+      secondary: { main: '#FBC978' },
+      background: {
+        default: mode === 'light' ? '#FEF8EE' : '#363636',
+        paper: mode === 'light' ? '#fff' : '#363636',
+      },
+      text: {
+        primary: mode === 'light' ? '#363636' : '#fff',
+      },
+    },
+    typography: {
+      fontFamily: 'Vazirmatn, sans-serif',
+    },
+  });
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const [mode, setMode] = React.useState<PaletteMode>('light');
+  const theme = React.useMemo(() => getTheme(mode), [mode]);
+
+  const toggleDarkMode = () =>
+    setMode((m) => (m === 'light' ? 'dark' : 'light'));
+
   React.useEffect(() => {
     const jssStyles = document.querySelector('#jss-server-side');
     if (jssStyles && jssStyles.parentElement) {
@@ -28,7 +53,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       </Head>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Component {...pageProps} />
+        <Layout darkMode={mode === 'dark'} toggleDarkMode={toggleDarkMode}>
+          <Component {...pageProps} />
+        </Layout>
       </ThemeProvider>
     </React.Fragment>
   );

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -8,6 +8,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Box,
 } from '@mui/material';
 
 interface Position {


### PR DESCRIPTION
## Summary
- add header/footer layout with dark mode toggle
- define MUI theme with brand colours and dark mode
- widen candidate table layout
- fix missing `Box` imports

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887464c44688326922f59310477228e