### PR TITLE
UI improvements and delete buttons

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -13,7 +13,10 @@ interface Props {
 export default function Layout({ children, darkMode, toggleDarkMode }: Props) {
   return (
     <Box>
-      <AppBar position="static" color="primary">
+      <AppBar
+        position="static"
+        sx={{ backgroundColor: '#ffffff', color: 'text.primary' }}
+      >
         <Toolbar>
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
             Candidate Manager

--- a/frontend/pages/[position]/candidates.tsx
+++ b/frontend/pages/[position]/candidates.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import VisibilityIcon from '@mui/icons-material/Visibility';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import AddCandidateDialog from '../../components/AddCandidateDialog';
 import ViewDrawer from '../../components/ViewDrawer';
@@ -35,6 +36,12 @@ export default function CandidateList() {
   const [search, setSearch] = useState('');
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selected, setSelected] = useState<Candidate | null>(null);
+
+  const deleteCandidate = async (id: number) => {
+    if (!confirm('Delete this candidate?')) return;
+    await fetch(`http://localhost:5000/delete/${id}`, { method: 'POST' });
+    fetchData();
+  };
 
   const fetchData = () => {
     if (!position) return;
@@ -100,6 +107,13 @@ export default function CandidateList() {
             aria-label="edit"
           >
             <EditIcon fontSize="inherit" />
+          </IconButton>
+          <IconButton
+            size="small"
+            onClick={() => deleteCandidate(params.row.id)}
+            aria-label="delete"
+          >
+            <DeleteIcon fontSize="inherit" />
           </IconButton>
         </>
       ),

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -16,8 +16,8 @@ const getTheme = (mode: PaletteMode) =>
       primary: { main: '#F7A043' },
       secondary: { main: '#FBC978' },
       background: {
-        default: mode === 'light' ? '#FEF8EE' : '#363636',
-        paper: mode === 'light' ? '#fff' : '#363636',
+        default: mode === 'light' ? '#ffffff' : '#363636',
+        paper: mode === 'light' ? '#ffffff' : '#363636',
       },
       text: {
         primary: mode === 'light' ? '#363636' : '#fff',

--- a/frontend/pages/edit/[id].tsx
+++ b/frontend/pages/edit/[id].tsx
@@ -13,7 +13,9 @@ import {
   FormControlLabel,
   Checkbox,
   Divider,
+  IconButton,
 } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 interface Candidate {
   [key: string]: any;
@@ -79,6 +81,13 @@ export default function EditPage() {
   };
 
   const addMeeting = () => setMeetings([...meetings, {}]);
+
+  const handleDelete = async () => {
+    if (!candidate) return;
+    if (!confirm('Delete this candidate?')) return;
+    await fetch(`http://localhost:5000/delete/${candidate.id}`, { method: 'POST' });
+    router.push('/');
+  };
 
   const handleSave = async () => {
     if (!candidate) return;
@@ -468,11 +477,14 @@ export default function EditPage() {
           </Button>
         </Box>
       )}
-      <Box sx={{ mt: 3 }}>
+      <Box sx={{ mt: 3, display: 'flex', alignItems: 'center', gap: 1 }}>
         <Button variant="contained" onClick={handleSave} sx={{ mr: 1 }}>
           Save
         </Button>
         <Button variant="outlined" onClick={() => router.push('/')}>Back</Button>
+        <IconButton color="error" onClick={handleDelete} sx={{ ml: 'auto' }}>
+          <DeleteIcon />
+        </IconButton>
       </Box>
     </Container>
   );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -67,7 +67,7 @@ export default function Home() {
         <Grid container spacing={3}>
           {positions.map((p) => (
             <Grid item key={p.id} xs={12} sm={6} md={4}>
-              <Card sx={{ minWidth: 220, bgcolor: 'grey.100', boxShadow: 3 }}>
+              <Card sx={{ minWidth: 220, bgcolor: 'grey.50', boxShadow: 1 }}>
                 <CardContent>
                   <Typography variant="h6" sx={{ mb: 1 }}>
                     {p.name}


### PR DESCRIPTION
## Summary
- modernize the layout with a white menu
- use white page background
- add delete icons to candidate rows
- allow deleting a candidate from the edit page
- simplify position cards style

## Testing
- `python -m py_compile app.py`
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68874992caa88326aa917fde5a8f8429