### PR TITLE
Add persistent theme mode

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import Link from 'next/link';
-import { AppBar, Toolbar, Typography, Button, IconButton, Box } from '@mui/material';
+import { AppBar, Toolbar, Typography, Button, IconButton, Box, useTheme } from '@mui/material';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
 
@@ -11,11 +11,12 @@ interface Props {
 }
 
 export default function Layout({ children, darkMode, toggleDarkMode }: Props) {
+  const theme = useTheme();
   return (
-    <Box>
+    <Box sx={{ backgroundColor: theme.palette.background.default, minHeight: '100vh' }}>
       <AppBar
         position="static"
-        sx={{ backgroundColor: '#ffffff', color: 'text.primary' }}
+        sx={{ bgcolor: 'background.paper', color: 'text.primary' }}
       >
         <Toolbar>
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
@@ -32,7 +33,9 @@ export default function Layout({ children, darkMode, toggleDarkMode }: Props) {
           </IconButton>
         </Toolbar>
       </AppBar>
-      <Box component="main">{children}</Box>
+      <Box component="main" sx={{ px: 2, py: 3 }}>
+        {children}
+      </Box>
       <Box component="footer" sx={{ textAlign: 'center', py: 1, fontSize: '0.8rem' }}>
         © {new Date().getFullYear()}
       </Box>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -16,11 +16,11 @@ const getTheme = (mode: PaletteMode) =>
       primary: { main: '#F7A043' },
       secondary: { main: '#FBC978' },
       background: {
-        default: mode === 'light' ? '#ffffff' : '#363636',
-        paper: mode === 'light' ? '#ffffff' : '#363636',
+        default: mode === 'light' ? '#ffffff' : '#000000',
+        paper: mode === 'light' ? '#ffffff' : '#000000',
       },
       text: {
-        primary: mode === 'light' ? '#363636' : '#fff',
+        primary: mode === 'light' ? '#363636' : '#ffffff',
       },
     },
     typography: {
@@ -36,11 +36,19 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     setMode((m) => (m === 'light' ? 'dark' : 'light'));
 
   React.useEffect(() => {
+    const stored = window.localStorage.getItem('color-mode') as PaletteMode | null;
+    if (stored === 'light' || stored === 'dark') {
+      setMode(stored);
+    }
     const jssStyles = document.querySelector('#jss-server-side');
     if (jssStyles && jssStyles.parentElement) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
   }, []);
+
+  React.useEffect(() => {
+    window.localStorage.setItem('color-mode', mode);
+  }, [mode]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Summary
- allow dark mode preference to persist via localStorage
- apply theme background colors for both modes
- make Layout use themed colors and padding

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688758f0c6588326889467becb4f7521