### PR TITLE
Fix MUI icon JSX type error

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ReactNode } from 'react';
 import Link from 'next/link';
 import { AppBar, Toolbar, Typography, Button, IconButton, Box, useTheme } from '@mui/material';


### PR DESCRIPTION
## Summary
- mark `Layout` as a client component so Material UI icons work

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68879b255e9c8326ac013defa590450d