### PR TITLE
Fix admin form type narrowing

### DIFF
--- a/frontend/pages/admin/position/[id].tsx
+++ b/frontend/pages/admin/position/[id].tsx
@@ -51,6 +51,18 @@ export default function PositionForm() {
   });
   const [tab, setTab] = useState(0);
 
+  const sections: Array<[
+    keyof Omit<GlobalForm, 'exp_per_year'>,
+    string
+  ]> = [
+    ['gender', 'Gender'],
+    ['education', 'Education'],
+    ['military_status', 'Military Status'],
+    ['job_status', 'Job Status'],
+    ['availability', 'Availability'],
+    ['reviewer_weights', 'Reviewer Weights'],
+  ];
+
   useEffect(() => {
     if (!id) return;
     if (id !== 'new') {
@@ -184,16 +196,7 @@ export default function PositionForm() {
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
-          {(
-            [
-              ['gender', 'Gender'],
-              ['education', 'Education'],
-              ['military_status', 'Military Status'],
-              ['job_status', 'Job Status'],
-              ['availability', 'Availability'],
-              ['reviewer_weights', 'Reviewer Weights'],
-            ] as [keyof Omit<GlobalForm, 'exp_per_year'>, string][]
-          ).map(([section, title]) => (
+          {sections.map(([section, title]) => (
             <Box key={section}>
               <Typography variant="subtitle1" gutterBottom>
                 {title}


### PR DESCRIPTION
## Summary
- define constant `sections` for general scoring fields in `PositionForm`
- iterate over that constant directly to avoid union issues

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68879c5cd6a083269a19e626ffe8a17f