### PR TITLE
Add delete icon to server candidate list

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Candidate List - Abriron</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <style>
     .action-btns button { margin-right: 4px; }
@@ -71,7 +72,9 @@
         <td class="action-btns">
           <a class="btn btn-sm btn-info" href="/view/{{ c.id }}">View</a>
           <a class="btn btn-sm btn-warning" href="/edit/{{ c.id }}">Edit</a>
-          <button class="btn btn-sm btn-danger" data-id="{{ c.id }}" onclick="confirmDelete(this)">Delete</button>
+          <button class="btn btn-sm btn-danger" data-id="{{ c.id }}" onclick="confirmDelete(this)" aria-label="Delete">
+            <i class="bi bi-trash"></i>
+          </button>
         </td>
         <td>
           {% if c.resume_file %}


### PR DESCRIPTION
## Summary
- use Bootstrap icons in index.html
- show trash icon for delete action

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6888b75ba8d08326bad76bdb6d2c5d76