### PR TITLE
Update buttons and add position deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,6 +233,18 @@ def save_position():
     return jsonify({'status': 'ok'})
 
 
+@app.route('/delete_position/<pos_id>', methods=['POST'])
+def delete_position(pos_id):
+    """Delete a position from the scoring configuration."""
+    config = load_scoring_config()
+    positions = config.get('positions', {})
+    if pos_id in positions:
+        del positions[pos_id]
+        with open(SCORING_CONFIG_FILE, 'w') as f:
+            json.dump(config, f, indent=2)
+    return jsonify({'status': 'ok'})
+
+
 @app.route('/save_global', methods=['POST'])
 def save_global():
     """Update global scoring configuration."""

--- a/frontend/pages/[position]/candidates.tsx
+++ b/frontend/pages/[position]/candidates.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import AddCandidateDialog from '../../components/AddCandidateDialog';
 import ViewDrawer from '../../components/ViewDrawer';
@@ -112,8 +112,9 @@ export default function CandidateList() {
             size="small"
             onClick={() => deleteCandidate(params.row.id)}
             aria-label="delete"
+            color="error"
           >
-            <DeleteOutlineIcon fontSize="inherit" />
+            <DeleteIcon fontSize="inherit" />
           </IconButton>
         </>
       ),

--- a/frontend/pages/admin/index.tsx
+++ b/frontend/pages/admin/index.tsx
@@ -9,7 +9,10 @@ import {
   ListItem,
   ListItemText,
   Box,
+  IconButton,
 } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 interface Position {
   id: string;
@@ -19,6 +22,12 @@ interface Position {
 export default function AdminPage() {
   const [positions, setPositions] = useState<Position[]>([]);
   const router = useRouter();
+
+  const deletePosition = async (id: string) => {
+    if (!confirm('Delete this position?')) return;
+    await fetch(`http://localhost:5000/delete_position/${id}`, { method: 'POST' });
+    setPositions((prev) => prev.filter((p) => p.id !== id));
+  };
 
   useEffect(() => {
     fetch('http://localhost:5000/api/positions')
@@ -48,9 +57,23 @@ export default function AdminPage() {
             key={p.id}
             divider
             secondaryAction={
-              <Button onClick={() => router.push(`/admin/position/${p.id}`)}>
-                Edit
-              </Button>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <IconButton
+                  edge="end"
+                  aria-label="edit"
+                  onClick={() => router.push(`/admin/position/${p.id}`)}
+                >
+                  <EditIcon />
+                </IconButton>
+                <IconButton
+                  edge="end"
+                  aria-label="delete"
+                  color="error"
+                  onClick={() => deletePosition(p.id)}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </Box>
             }
           >
             <ListItemText primary={p.name} secondary={p.id} />


### PR DESCRIPTION
## Summary
- style candidate delete action like the edit form button
- allow deleting positions from the admin list
- expose `/delete_position/<id>` backend endpoint

## Testing
- `python -m py_compile app.py`
- `npm -C frontend run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888bad5e3088326ab8299292166b968